### PR TITLE
More verbose logging on failed subprocess

### DIFF
--- a/sagify/commands/build.py
+++ b/sagify/commands/build.py
@@ -8,6 +8,7 @@ import click
 from sagify.api import build as api_build
 from sagify.commands import ASCII_LOGO
 from sagify.log import logger
+from future.moves import subprocess
 
 click.disable_unicode_literals_warning = True
 
@@ -29,6 +30,9 @@ def build(dir, requirements_dir):
     except ValueError:
         logger.info("This is not a sagify directory: {}".format(dir))
         sys.exit(-1)
+    except subprocess.CalledProcessError as e:
+        logger.debug(e.output)
+        raise
     except Exception as e:
         logger.info("{}".format(e))
         return

--- a/sagify/commands/local.py
+++ b/sagify/commands/local.py
@@ -8,6 +8,7 @@ import click
 from sagify.api import local as api_local
 from sagify.commands import ASCII_LOGO
 from sagify.log import logger
+from future.moves import subprocess
 
 click.disable_unicode_literals_warning = True
 
@@ -36,6 +37,9 @@ def train(dir):
     except ValueError:
         logger.info("This is not a sagify directory: {}".format(dir))
         sys.exit(-1)
+    except subprocess.CalledProcessError as e:
+        logger.debug(e.output)
+        raise
     except Exception as e:
         logger.info("{}".format(e))
         return
@@ -55,6 +59,9 @@ def deploy(dir):
     except ValueError:
         logger.info("This is not a sagify directory: {}".format(dir))
         sys.exit(-1)
+    except subprocess.CalledProcessError as e:
+        logger.debug(e.output)
+        raise
     except Exception as e:
         logger.info("{}".format(e))
         return

--- a/sagify/commands/push.py
+++ b/sagify/commands/push.py
@@ -8,6 +8,7 @@ import click
 from sagify.api import push as api_push
 from sagify.commands import ASCII_LOGO
 from sagify.log import logger
+from future.moves import subprocess
 
 click.disable_unicode_literals_warning = True
 
@@ -30,6 +31,9 @@ def push(dir):
     except ValueError:
         logger.info("This is not a sagify directory: {}".format(dir))
         sys.exit(-1)
+    except subprocess.CalledProcessError as e:
+        logger.debug(e.output)
+        raise
     except Exception as e:
         logger.info("{}".format(e))
         return


### PR DESCRIPTION
I had lots of trouble debugging why my docker builds were failing, so I added code to catch the `subprocess.CalledProcessError` for every command where `subprocess.checkOutput()` is called.

This outputs using `logger.debug()`, so this additional output will only be visible if the user adds the `-v` flag at the command line.