### PR TITLE
Optimize Dockerfile

### DIFF
--- a/sagify/template/{{ cookiecutter.module_slug }}/Dockerfile
+++ b/sagify/template/{{ cookiecutter.module_slug }}/Dockerfile
@@ -27,11 +27,12 @@ ARG module_path
 ARG target_dir_name
 
 COPY ${requirements_file_path} /opt/program/sagify-requirements.txt
-COPY ${module_path} /opt/program/${target_dir_name}
 WORKDIR /opt/program/${target_dir_name}
 
 # Here we get all python packages.
 RUN pip install flask gevent gunicorn future
 RUN pip install -r ../sagify-requirements.txt && rm -rf /root/.cache
+
+COPY ${module_path} /opt/program/${target_dir_name}
 
 ENTRYPOINT ["sagify/executor.sh"]

--- a/sagify/template/{{ cookiecutter.module_slug }}/build.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/build.sh
@@ -9,11 +9,11 @@ requirements_file_path=$4
 
 image={{ cookiecutter.project_slug }}-img
 
-img_id=$(docker images ${image} -q)
-if [ "$img_id" != "" ]
-then
-    docker rmi -f ${img_id}
-fi
+# img_id=$(docker images ${image} -q)
+# if [ "$img_id" != "" ]
+# then
+#     docker rmi -f ${img_id}
+# fi
 
 # Build the docker image
 

--- a/sagify/template/{{ cookiecutter.module_slug }}/build.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/build.sh
@@ -9,12 +9,6 @@ requirements_file_path=$4
 
 image={{ cookiecutter.project_slug }}-img
 
-# img_id=$(docker images ${image} -q)
-# if [ "$img_id" != "" ]
-# then
-#     docker rmi -f ${img_id}
-# fi
-
 # Build the docker image
 
 docker build -t ${image} -f ${dockerfile_path} . --build-arg module_path=${module_path} --build-arg target_dir_name=${target_dir_name} --build-arg requirements_file_path=${requirements_file_path}


### PR DESCRIPTION
I found that building the docker image took a while because the default build.sh script deletes the previous image and rebuilds from scratch. IDK if there's a good reason for that, but I commented those lines out and my builds still work, and finish much faster.

I also found that reordering one of the COPY commands in the Dockerfile sped the build up significantly, because it does not require all Python modules to be reinstalled every time a change is made to the code base. 