### PR TITLE
Add option to specify docker tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--time-out TIME_OUT_IN_SECS` or `-s TIME_OUT_IN_SECS`: Time-out in seconds (default: 24 * 60 * 60)
 
-`--aws-tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+`--aws-tags TAGS` or `-a TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
 
 #### Example
 
@@ -410,7 +410,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
 
-`--aws-tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+`--aws-tags TAGS` or `-a TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Executes a Docker image in train mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--tags TAGS]
+    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS]
 
 #### Description
 
@@ -377,7 +377,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--time-out TIME_OUT_IN_SECS` or `-s TIME_OUT_IN_SECS`: Time-out in seconds (default: 24 * 60 * 60)
 
-`--tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+`--aws-tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
 
 #### Example
 
@@ -392,7 +392,7 @@ Executes a Docker image in serve mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud deploy --s3-model-location S3_LOCATION_TO_MODEL_TAR_GZ --num-instance NUMBER_OF_EC2_INSTANCES --ec2-type EC2_TYPE [--dir SRC_DIR] [--tags TAGS]
+    sagify cloud deploy --s3-model-location S3_LOCATION_TO_MODEL_TAR_GZ --num-instance NUMBER_OF_EC2_INSTANCES --ec2-type EC2_TYPE [--dir SRC_DIR] [--aws-tags TAGS]
 
 #### Description
 
@@ -410,7 +410,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
 
-`--tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+`--aws-tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -459,7 +459,7 @@ Executes a Docker image in train mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--tags TAGS]
+    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS]
 
 #### Description
 
@@ -483,7 +483,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--time-out TIME_OUT_IN_SECS` or `-s TIME_OUT_IN_SECS`: Time-out in seconds (default: 24 * 60 * 60)
 
-`--tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+`--aws-tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
 
 #### Example
 
@@ -498,7 +498,7 @@ Executes a Docker image in serve mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud deploy --s3-model-location S3_LOCATION_TO_MODEL_TAR_GZ --num-instance NUMBER_OF_EC2_INSTANCES --ec2-type EC2_TYPE [--dir SRC_DIR] [--tags TAGS]
+    sagify cloud deploy --s3-model-location S3_LOCATION_TO_MODEL_TAR_GZ --num-instance NUMBER_OF_EC2_INSTANCES --ec2-type EC2_TYPE [--dir SRC_DIR] [--aws-tags TAGS]
 
 #### Description
 
@@ -516,7 +516,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
 
-`--tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+`--aws-tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -483,7 +483,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--time-out TIME_OUT_IN_SECS` or `-s TIME_OUT_IN_SECS`: Time-out in seconds (default: 24 * 60 * 60)
 
-`--aws-tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+`--aws-tags TAGS` or `-a TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
 
 #### Example
 
@@ -516,7 +516,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
 
-`--aws-tags TAGS` or `-t TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+`--aws-tags TAGS` or `-a TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
 
 #### Example
 

--- a/sagify/__main__.py
+++ b/sagify/__main__.py
@@ -13,11 +13,14 @@ from sagify.log import configure_logger
 
 @click.group()
 @click.option(u"-v", u"--verbose", count=True, help=u"Turn on debug logging")
-def cli(verbose):
+@click.option(u"-t", u"--docker-tag", default=u"latest", help=u"Specify tag for Docker image")
+@click.pass_context
+def cli(ctx, verbose, docker_tag):
     """
     Sagify enables training and deploying machine learning models on AWS SageMaker in a few minutes!
     """
     configure_logger(verbose)
+    ctx.obj = {'docker_tag': docker_tag}
 
 
 def add_commands(cli):

--- a/sagify/api/build.py
+++ b/sagify/api/build.py
@@ -8,7 +8,7 @@ from future.moves import subprocess
 from sagify.log import logger
 
 
-def build(dir, requirements_dir):
+def build(dir, requirements_dir, docker_tag):
     """
     Builds a Docker image that contains code under the given source root directory.
 
@@ -42,7 +42,8 @@ def build(dir, requirements_dir):
             "{}".format(os.path.relpath(dir)),
             "{}".format(os.path.relpath(target_dir_name)),
             "{}".format(dockerfile_path),
-            "{}".format(os.path.relpath(requirements_dir))
+            "{}".format(os.path.relpath(requirements_dir)),
+            docker_tag
         ]
     )
     logger.debug(output)

--- a/sagify/api/cloud.py
+++ b/sagify/api/cloud.py
@@ -50,6 +50,7 @@ def train(
         ec2_type,
         volume_size,
         time_out,
+        docker_tag,
         tags=None
 ):
     """
@@ -84,8 +85,10 @@ def train(
     hyperparams_dict = _read_hyperparams_config(hyperparams_file) if hyperparams_file else None
     sage_maker_client = sagemaker.SageMakerClient(config.aws_profile, config.aws_region)
 
+    image_name = config.image_name+':'+docker_tag
+
     return sage_maker_client.train(
-        image_name=config.image_name,
+        image_name=image_name,
         input_s3_data_location=input_s3_dir,
         train_instance_count=1,
         train_instance_type=ec2_type,
@@ -97,7 +100,7 @@ def train(
     )
 
 
-def deploy(dir, s3_model_location, num_instances, ec2_type, tags=None):
+def deploy(dir, s3_model_location, num_instances, ec2_type, docker_tag, tags=None):
     """
     Deploys ML model(s) on SageMaker
 
@@ -124,10 +127,11 @@ def deploy(dir, s3_model_location, num_instances, ec2_type, tags=None):
     :return: [str], endpoint name
     """
     config = _read_config(dir)
+    image_name = config.image_name+':'+docker_tag
 
     sage_maker_client = sagemaker.SageMakerClient(config.aws_profile, config.aws_region)
     return sage_maker_client.deploy(
-        image_name=config.image_name,
+        image_name=image_name,
         s3_model_location=s3_model_location,
         train_instance_count=num_instances,
         train_instance_type=ec2_type,

--- a/sagify/api/local.py
+++ b/sagify/api/local.py
@@ -8,7 +8,7 @@ from future.moves import subprocess
 from sagify.log import logger
 
 
-def train(dir):
+def train(dir, docker_tag):
     """
     Trains ML model(s) locally
 
@@ -24,13 +24,14 @@ def train(dir):
     output = subprocess.check_output(
         [
             "{}".format(local_train_script_path),
-            "{}".format(os.path.abspath(test_path))
+            "{}".format(os.path.abspath(test_path)),
+            docker_tag
         ]
     )
     logger.debug(output)
 
 
-def deploy(dir):
+def deploy(dir, docker_tag):
     """
     Deploys ML models(s) locally
 
@@ -46,7 +47,8 @@ def deploy(dir):
     output = subprocess.check_output(
         [
             "{}".format(local_deploy_script_path),
-            "{}".format(os.path.abspath(test_path))
+            "{}".format(os.path.abspath(test_path)),
+            docker_tag
         ]
     )
     logger.debug(output)

--- a/sagify/api/push.py
+++ b/sagify/api/push.py
@@ -8,7 +8,7 @@ from future.moves import subprocess
 from sagify.log import logger
 
 
-def push(dir):
+def push(dir, docker_tag):
     """
     Push Docker image to AWS ECS
 
@@ -21,5 +21,5 @@ def push(dir):
     if not os.path.isfile(push_script_path):
         raise ValueError("This is not a sagify directory: {}".format(dir))
 
-    output = subprocess.check_output(["{}".format(push_script_path)])
+    output = subprocess.check_output(["{}".format(push_script_path), docker_tag])
     logger.debug(output)

--- a/sagify/commands/build.py
+++ b/sagify/commands/build.py
@@ -16,7 +16,8 @@ click.disable_unicode_literals_warning = True
 @click.command()
 @click.option(u"-d", u"--dir", required=False, default='.', help="Path to sagify module")
 @click.option(u"-r", u"--requirements-dir", required=True, help="Path to requirements.txt file")
-def build(dir, requirements_dir):
+@click.pass_obj
+def build(obj, dir, requirements_dir):
     """
     Command to build SageMaker app
     """
@@ -24,7 +25,7 @@ def build(dir, requirements_dir):
     logger.info("Started building SageMaker Docker image. It will take some minutes...\n")
 
     try:
-        api_build.build(dir=dir, requirements_dir=requirements_dir)
+        api_build.build(dir=dir, requirements_dir=requirements_dir, docker_tag=obj['docker_tag'])
 
         logger.info("Docker image built successfully!")
     except ValueError:

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -84,7 +84,7 @@ def upload_data(dir, input_dir, s3_dir):
     help="time-out in seconds (default: 24 * 60 * 60)"
 )
 @click.option(
-    u"-t", u"--tags",
+    u"-t", u"--aws-tags",
     callback=validate_tags,
     required=False,
     default=None,
@@ -137,7 +137,7 @@ def train(
 @click.option(u"-n", u"--num-instances", required=True, type=int, help="Number of ec2 instances")
 @click.option(u"-e", u"--ec2-type", required=True, help="ec2 instance type")
 @click.option(
-    u"-t", u"--tags",
+    u"-t", u"--aws-tags",
     callback=validate_tags,
     required=False,
     default=None,

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -91,7 +91,9 @@ def upload_data(dir, input_dir, s3_dir):
     help='Tags for labeling a training job of the form "tag1=value1;tag2=value2". For more, see '
          'https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.'
 )
+@click.pass_obj
 def train(
+        obj,
         dir,
         input_s3_dir,
         output_s3_dir,
@@ -116,6 +118,7 @@ def train(
             ec2_type=ec2_type,
             volume_size=volume_size,
             time_out=time_out,
+            docker_tag=obj['docker_tag'],
             tags=tags
         )
 
@@ -144,7 +147,8 @@ def train(
     help='Tags for labeling a training job of the form "tag1=value1;tag2=value2". For more, see '
          'https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.'
 )
-def deploy(dir, s3_model_location, num_instances, ec2_type, tags):
+@click.pass_obj
+def deploy(obj, dir, s3_model_location, num_instances, ec2_type, tags):
     """
     Command to deploy ML model(s) on SageMaker
     """
@@ -157,6 +161,7 @@ def deploy(dir, s3_model_location, num_instances, ec2_type, tags):
             s3_model_location=s3_model_location,
             num_instances=num_instances,
             ec2_type=ec2_type,
+            docker_tag=obj['docker_tag'],
             tags=tags
         )
 

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -84,7 +84,7 @@ def upload_data(dir, input_dir, s3_dir):
     help="time-out in seconds (default: 24 * 60 * 60)"
 )
 @click.option(
-    u"-t", u"--aws-tags",
+    u"-a", u"--aws-tags",
     callback=validate_tags,
     required=False,
     default=None,
@@ -140,7 +140,7 @@ def train(
 @click.option(u"-n", u"--num-instances", required=True, type=int, help="Number of ec2 instances")
 @click.option(u"-e", u"--ec2-type", required=True, help="ec2 instance type")
 @click.option(
-    u"-t", u"--aws-tags",
+    u"-a", u"--aws-tags",
     callback=validate_tags,
     required=False,
     default=None,

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -101,7 +101,7 @@ def train(
         ec2_type,
         volume_size,
         time_out,
-        tags
+        aws_tags
 ):
     """
     Command to train ML model(s) on SageMaker
@@ -119,7 +119,7 @@ def train(
             volume_size=volume_size,
             time_out=time_out,
             docker_tag=obj['docker_tag'],
-            tags=tags
+            tags=aws_tags
         )
 
         logger.info("Training on SageMaker succeeded")
@@ -148,7 +148,7 @@ def train(
          'https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.'
 )
 @click.pass_obj
-def deploy(obj, dir, s3_model_location, num_instances, ec2_type, tags):
+def deploy(obj, dir, s3_model_location, num_instances, ec2_type, aws_tags):
     """
     Command to deploy ML model(s) on SageMaker
     """
@@ -162,7 +162,7 @@ def deploy(obj, dir, s3_model_location, num_instances, ec2_type, tags):
             num_instances=num_instances,
             ec2_type=ec2_type,
             docker_tag=obj['docker_tag'],
-            tags=tags
+            tags=aws_tags
         )
 
         logger.info("Model deployed to SageMaker successfully")

--- a/sagify/commands/local.py
+++ b/sagify/commands/local.py
@@ -23,7 +23,8 @@ def local():
 
 @click.command()
 @click.option(u"-d", u"--dir", required=False, default='.', help="Path to sagify module")
-def train(dir):
+@click.pass_obj
+def train(obj, dir):
     """
     Command to train ML model(s) locally
     """
@@ -31,7 +32,7 @@ def train(dir):
     logger.info("Started local training...\n")
 
     try:
-        api_local.train(dir=dir)
+        api_local.train(dir=dir, docker_tag=obj['docker_tag'])
 
         logger.info("Local training completed successfully!")
     except ValueError:
@@ -47,7 +48,8 @@ def train(dir):
 
 @click.command()
 @click.option(u"-d", u"--dir", required=False, default='.', help="Path to sagify module")
-def deploy(dir):
+@click.pass_obj
+def deploy(obj, dir):
     """
     Command to deploy ML model(s) locally
     """
@@ -55,7 +57,7 @@ def deploy(dir):
     logger.info("Started local deployment at localhost:8080 ...\n")
 
     try:
-        api_local.deploy(dir=dir)
+        api_local.deploy(dir=dir, docker_tag=obj['docker_tag'])
     except ValueError:
         logger.info("This is not a sagify directory: {}".format(dir))
         sys.exit(-1)

--- a/sagify/commands/push.py
+++ b/sagify/commands/push.py
@@ -15,7 +15,8 @@ click.disable_unicode_literals_warning = True
 
 @click.command()
 @click.option(u"-d", u"--dir", required=False, default='.', help="Path to sagify module")
-def push(dir):
+@click.pass_obj
+def push(obj, dir):
     """
     Command to push Docker image to AWS ECS
     """
@@ -25,7 +26,7 @@ def push(dir):
     )
 
     try:
-        api_push.push(dir=dir)
+        api_push.push(dir=dir, docker_tag=obj['docker_tag'])
 
         logger.info("Docker image pushed to ECS successfully!")
     except ValueError:

--- a/sagify/template/{{ cookiecutter.module_slug }}/build.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/build.sh
@@ -6,9 +6,10 @@ module_path=$1
 target_dir_name=$2
 dockerfile_path=$3
 requirements_file_path=$4
+tag=$5
 
 image={{ cookiecutter.project_slug }}-img
 
 # Build the docker image
 
-docker build -t ${image} -f ${dockerfile_path} . --build-arg module_path=${module_path} --build-arg target_dir_name=${target_dir_name} --build-arg requirements_file_path=${requirements_file_path}
+docker build -t "${image}:${tag}" -f ${dockerfile_path} . --build-arg module_path=${module_path} --build-arg target_dir_name=${target_dir_name} --build-arg requirements_file_path=${requirements_file_path}

--- a/sagify/template/{{ cookiecutter.module_slug }}/local_test/deploy_local.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/local_test/deploy_local.sh
@@ -2,5 +2,6 @@
 
 image={{ cookiecutter.project_slug }}-img
 test_path=$1
+tag=$2
 
-docker run -it -v ${test_path}:/opt/ml -p 8080:8080 --rm ${image} serve
+docker run -it -v ${test_path}:/opt/ml -p 8080:8080 --rm "${image}:${tag}" serve

--- a/sagify/template/{{ cookiecutter.module_slug }}/local_test/train_local.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/local_test/train_local.sh
@@ -2,5 +2,6 @@
 
 image={{ cookiecutter.project_slug }}-img
 test_path=$1
+tag=$2
 
-docker run -v ${test_path}:/opt/ml --rm ${image} train
+docker run -v ${test_path}:/opt/ml --rm "${image}:${tag}" train

--- a/sagify/template/{{ cookiecutter.module_slug }}/push.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/push.sh
@@ -6,6 +6,7 @@
 # The argument to this script is the image name. This will be used as the image on the local
 # machine and combined with the account and region to form the repository name for ECR.
 image={{ cookiecutter.project_slug }}-img
+tag=$1
 
 profile={{ cookiecutter.aws_profile }}
 region={{ cookiecutter.aws_region }}
@@ -19,7 +20,7 @@ then
 fi
 
 
-fullname="${account}.dkr.ecr.${region}.amazonaws.com/${image}:latest"
+fullname="${account}.dkr.ecr.${region}.amazonaws.com/${image}:${tag}"
 
 # If the repository doesn't exist in ECR, create it.
 
@@ -35,6 +36,6 @@ $(aws ecr get-login --profile ${profile} --region ${region} --no-include-email)
 
 # Push Docker image to ECR with the full name.
 
-docker tag ${image} ${fullname}
+docker tag ${image}:${tag} ${fullname}
 
 docker push ${fullname}

--- a/tests/commands/test_cloud.py
+++ b/tests/commands/test_cloud.py
@@ -192,7 +192,7 @@ class TestTrain(object):
                                 '-i', 's3://bucket/input',
                                 '-o', 's3://bucket/output',
                                 '-e', 'ml.c4.2xlarge',
-                                '-t', 'key1=value1;key2=2'
+                                '-a', 'key1=value1;key2=2'
                             ]
                         )
 
@@ -422,7 +422,7 @@ class TestDeploy(object):
                                 '-m', 's3://bucket/model/location/model.tar.gz',
                                 '-n', '2',
                                 '-e', 'ml.c4.2xlarge',
-                                '-t', 'key1=value1;key2=2'
+                                '-a', 'key1=value1;key2=2'
                             ]
                         )
 

--- a/tests/commands/test_cloud.py
+++ b/tests/commands/test_cloud.py
@@ -152,7 +152,7 @@ class TestTrain(object):
 
                         assert instance.train.call_count == 1
                         instance.train.assert_called_with(
-                            image_name='sagemaker-img',
+                            image_name='sagemaker-img:latest',
                             input_s3_data_location='s3://bucket/input',
                             train_instance_count=1,
                             train_instance_type='ml.c4.2xlarge',
@@ -198,7 +198,7 @@ class TestTrain(object):
 
                         assert instance.train.call_count == 1
                         instance.train.assert_called_with(
-                            image_name='sagemaker-img',
+                            image_name='sagemaker-img:latest',
                             input_s3_data_location='s3://bucket/input',
                             train_instance_count=1,
                             train_instance_type='ml.c4.2xlarge',
@@ -256,7 +256,7 @@ class TestTrain(object):
 
                         assert instance.train.call_count == 1
                         instance.train.assert_called_with(
-                            image_name='sagemaker-img',
+                            image_name='sagemaker-img:latest',
                             input_s3_data_location='s3://bucket/input',
                             train_instance_count=1,
                             train_instance_type='ml.c4.2xlarge',
@@ -341,7 +341,7 @@ class TestDeploy(object):
 
                         assert instance.deploy.call_count == 1
                         instance.deploy.assert_called_with(
-                            image_name='sagemaker-img',
+                            image_name='sagemaker-img:latest',
                             s3_model_location='s3://bucket/model/location/model.tar.gz',
                             train_instance_count=2,
                             train_instance_type='ml.c4.2xlarge',
@@ -386,7 +386,7 @@ class TestDeploy(object):
 
                         assert instance.deploy.call_count == 1
                         instance.deploy.assert_called_with(
-                            image_name='sagemaker-img',
+                            image_name='sagemaker-img:latest',
                             s3_model_location='s3://bucket/model/location/model.tar.gz',
                             train_instance_count=2,
                             train_instance_type='ml.c4.2xlarge',
@@ -428,7 +428,7 @@ class TestDeploy(object):
 
                         assert instance.deploy.call_count == 1
                         instance.deploy.assert_called_with(
-                            image_name='sagemaker-img',
+                            image_name='sagemaker-img:latest',
                             s3_model_location='s3://bucket/model/location/model.tar.gz',
                             train_instance_count=2,
                             train_instance_type='ml.c4.2xlarge',


### PR DESCRIPTION
Add an optional argument to sagify to specify a tag for the docker image. This impacts the `local`, `push`, `build`, and `cloud` subcommands.

If no tag is specified, this defaults to using "latest", the default tag for a docker image.

Usage:
`sagify -t <tag>`
or
`sagify --docker-tag <tag>`