### PR TITLE
Add name and version to setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,4 @@
 [metadata]
-name = sagify
-version = 0.11.0
 author = Pavlos Mitsoulis Ntompos
 author-email = pavlos@kenza.ai
 summary = Train and deploy machine learning models on AWS SageMaker in a few simple steps!

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(
+    name='sagify',
+    version='0.11.0',
     setup_cfg=True,
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
     packages=find_packages(where='.'),


### PR DESCRIPTION
When name and version not specified in setup.py sagify showed
up as UNKNOWN==0.0.0 when using pip freeze list. This also meant that in order to uninstall had to do:

pip uninstall UNKNOWN

as pip uninstall sagify would fail:

      pip uninstall sagify
      Cannot uninstall requirement sagify, not installed

      pip uninstall UNKNOWN
      Uninstalling UNKNOWN-0.0.0:

Example output when installing with pip before specifying name + version in setup.py:
  Running setup.py (path:/tmp/pip-build-9uuuczo2/sagify/setup.py) egg_info for package sagify produced metadata for project name **unknown**. Fix your #egg=sagify fragments.
Collecting boto3<1.7.99,==1.7.41 (from **unknown**)
