### PR TITLE
Feature/support dynamic aws profile and region for push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,8 @@ Pushes a Docker image to AWS Elastic Container Service
 
 #### Synopsis
 
-    sagify push [--dir SRC_DIR]
-    
+    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME]
+
 #### Description
 
 This command pushes an already built Docker image to AWS Elastic Container Service. Later on, AWS SageMaker will consume that image from AWS Elastic Container Service for train and serve mode.
@@ -310,6 +310,8 @@ This command pushes an already built Docker image to AWS Elastic Container Servi
 #### Optional Flags
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
+
+`--aws-profile PROFILE_NAME` or `-p PROFILE_NAME`: AWS profile to use for pushing to ECR
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Pushes a Docker image to AWS Elastic Container Service
 
 #### Synopsis
 
-    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME]
+    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION]
 
 #### Description
 
@@ -310,6 +310,8 @@ This command pushes an already built Docker image to AWS Elastic Container Servi
 #### Optional Flags
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
+
+`--aws-region AWS_REGION` or `-r AWS_REGION`: The AWS region to push the image to
 
 `--aws-profile PROFILE_NAME` or `-p PROFILE_NAME`: AWS profile to use for pushing to ECR
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -407,7 +407,7 @@ Pushes a Docker image to AWS Elastic Container Service
 
 #### Synopsis
 
-    sagify push [--dir SRC_DIR]
+    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME]
     
 #### Description
 
@@ -416,6 +416,8 @@ This command pushes an already built Docker image to AWS Elastic Container Servi
 #### Optional Flags
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
+
+`--aws-profile PROFILE_NAME` or `-p PROFILE_NAME`: AWS profile to use for pushing to ECR
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -407,7 +407,7 @@ Pushes a Docker image to AWS Elastic Container Service
 
 #### Synopsis
 
-    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME]
+    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION]
     
 #### Description
 
@@ -416,6 +416,8 @@ This command pushes an already built Docker image to AWS Elastic Container Servi
 #### Optional Flags
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
+
+`--aws-region AWS_REGION` or `-r AWS_REGION`: The AWS region to push the image to
 
 `--aws-profile PROFILE_NAME` or `-p PROFILE_NAME`: AWS profile to use for pushing to ECR
 

--- a/sagify/api/push.py
+++ b/sagify/api/push.py
@@ -14,7 +14,7 @@ def push(dir, docker_tag, aws_region, aws_profile):
 
     :param dir: [str], source root directory
     :param docker_tag: [str], the Docker tag for the image
-    :param docker_tag: [str], the AWS region to push the image to
+    :param aws_region: [str], the AWS region to push the image to
     :param aws_profile: [str], the AWS profile used to push the image to ECR
     """
     sagify_module_path = os.path.relpath(os.path.join(dir, 'sagify/'))

--- a/sagify/api/push.py
+++ b/sagify/api/push.py
@@ -8,12 +8,13 @@ from future.moves import subprocess
 from sagify.log import logger
 
 
-def push(dir, docker_tag, aws_profile):
+def push(dir, docker_tag, aws_region, aws_profile):
     """
     Push Docker image to AWS ECS
 
     :param dir: [str], source root directory
     :param docker_tag: [str], the Docker tag for the image
+    :param docker_tag: [str], the AWS region to push the image to
     :param aws_profile: [str], the AWS profile used to push the image to ECR
     """
     sagify_module_path = os.path.relpath(os.path.join(dir, 'sagify/'))
@@ -23,5 +24,5 @@ def push(dir, docker_tag, aws_profile):
     if not os.path.isfile(push_script_path):
         raise ValueError("This is not a sagify directory: {}".format(dir))
 
-    output = subprocess.check_output(["{}".format(push_script_path), docker_tag, aws_profile])
+    output = subprocess.check_output(["{}".format(push_script_path), docker_tag, aws_region, aws_profile])
     logger.debug(output)

--- a/sagify/api/push.py
+++ b/sagify/api/push.py
@@ -8,12 +8,13 @@ from future.moves import subprocess
 from sagify.log import logger
 
 
-def push(dir, docker_tag):
+def push(dir, docker_tag, aws_profile):
     """
     Push Docker image to AWS ECS
 
     :param dir: [str], source root directory
     :param docker_tag: [str], the Docker tag for the image
+    :param aws_profile: [str], the AWS profile used to push the image to ECR
     """
     sagify_module_path = os.path.relpath(os.path.join(dir, 'sagify/'))
 
@@ -22,5 +23,5 @@ def push(dir, docker_tag):
     if not os.path.isfile(push_script_path):
         raise ValueError("This is not a sagify directory: {}".format(dir))
 
-    output = subprocess.check_output(["{}".format(push_script_path), docker_tag])
+    output = subprocess.check_output(["{}".format(push_script_path), docker_tag, aws_profile])
     logger.debug(output)

--- a/sagify/commands/push.py
+++ b/sagify/commands/push.py
@@ -15,8 +15,9 @@ click.disable_unicode_literals_warning = True
 
 @click.command()
 @click.option(u"-d", u"--dir", required=False, default='.', help="Path to sagify module")
+@click.option(u"-p", u"--aws-profile", required=True, help="The AWS profile to use for the push command")
 @click.pass_obj
-def push(obj, dir):
+def push(obj, dir, aws_profile):
     """
     Command to push Docker image to AWS ECS
     """
@@ -26,7 +27,7 @@ def push(obj, dir):
     )
 
     try:
-        api_push.push(dir=dir, docker_tag=obj['docker_tag'])
+        api_push.push(dir=dir, docker_tag=obj['docker_tag'], aws_profile=aws_profile)
 
         logger.info("Docker image pushed to ECS successfully!")
     except ValueError:

--- a/sagify/commands/push.py
+++ b/sagify/commands/push.py
@@ -15,9 +15,10 @@ click.disable_unicode_literals_warning = True
 
 @click.command()
 @click.option(u"-d", u"--dir", required=False, default='.', help="Path to sagify module")
+@click.option(u"-r", u"--aws-region", required=False, help="The AWS region to push the image to")
 @click.option(u"-p", u"--aws-profile", required=False, help="The AWS profile to use for the push command")
 @click.pass_obj
-def push(obj, dir, aws_profile):
+def push(obj, dir, aws_region, aws_profile):
     """
     Command to push Docker image to AWS ECS
     """
@@ -27,7 +28,7 @@ def push(obj, dir, aws_profile):
     )
 
     try:
-        api_push.push(dir=dir, docker_tag=obj['docker_tag'], aws_profile=aws_profile)
+        api_push.push(dir=dir, docker_tag=obj['docker_tag'], aws_region=aws_region, aws_profile=aws_profile)
 
         logger.info("Docker image pushed to ECS successfully!")
     except ValueError:

--- a/sagify/commands/push.py
+++ b/sagify/commands/push.py
@@ -15,7 +15,7 @@ click.disable_unicode_literals_warning = True
 
 @click.command()
 @click.option(u"-d", u"--dir", required=False, default='.', help="Path to sagify module")
-@click.option(u"-p", u"--aws-profile", required=True, help="The AWS profile to use for the push command")
+@click.option(u"-p", u"--aws-profile", required=False, help="The AWS profile to use for the push command")
 @click.pass_obj
 def push(obj, dir, aws_profile):
     """

--- a/sagify/template/{{ cookiecutter.module_slug }}/push.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/push.sh
@@ -7,8 +7,11 @@
 # machine and combined with the account and region to form the repository name for ECR.
 image={{ cookiecutter.project_slug }}-img
 tag=$1
+profile=$2
 
-profile={{ cookiecutter.aws_profile }}
+if [-z "$profile"]; then 
+    profile={{ cookiecutter.aws_profile }}
+fi 
 region={{ cookiecutter.aws_region }}
 
 # Get the account number associated with the current IAM credentials

--- a/sagify/template/{{ cookiecutter.module_slug }}/push.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/push.sh
@@ -7,12 +7,16 @@
 # machine and combined with the account and region to form the repository name for ECR.
 image={{ cookiecutter.project_slug }}-img
 tag=$1
-profile=$2
+region=$2
+profile=$3
 
 if [-z "$profile"]; then 
     profile={{ cookiecutter.aws_profile }}
 fi 
-region={{ cookiecutter.aws_region }}
+
+if [-z "$region"]; then 
+    region={{ cookiecutter.aws_region }}
+fi 
 
 # Get the account number associated with the current IAM credentials
 account=$(aws sts get-caller-identity --profile ${profile} --query Account --output text)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,5 +24,5 @@ description-file = README.md
 universal=1
 
 [flake8]
-max-line-length=100
+max-line-length=130
 exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,venv/,sagify/commands/__init__.py

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 try:
     from unittest import TestCase
     from unittest.mock import patch
@@ -8,47 +10,51 @@ from click.testing import CliRunner
 
 from sagify.__main__ import cli
 
+Case = namedtuple('Case', 'description, init_cmd, push_cmd, expected_exit_code, expected_cli_call')
+
+t1 = Case('default profile and region', ['init'], ['push'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, None]))
+
+t2 = Case('custom profile — default region', ['init'], ['push', '-p', 'some-profile'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, 'some-profile']))
+
+t3 = Case('default profile – custom region', ['init'], ['push', '-r', 'some-region'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', None]))
+
+t4 = Case('custom profile — custom region', ['init'], ['push', '-r', 'some-region', '-p', 'some-profile'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', 'some-profile']))
+
+t5 = Case('custom dir — default profile and region', ['init', '-d', 'src/'], ['push', '-d', 'src/'], 0,
+          lambda command_line: command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', None, None]))
+
+t6 = Case('custom invalid dir — default profile and region', ['init', '-d', 'src/'], ['push', '-d', 'invalid_dir/'], -1,
+          lambda command_line: command_line.assert_not_called())
+
+test_cases = [t1, t2, t3, t4, t5, t6]
+
+# Mocks
+command_line_mock = patch('future.moves.subprocess.check_output', return_value=None)
+patch('sagify.commands.initialize._get_local_aws_profiles', return_value=['default', 'sagemaker']).start()
+
 
 class PushCommandTests(TestCase):
-    def setUp(self):
-        self.runner = CliRunner()
-        self.command_line = patch('future.moves.subprocess.check_output', return_value=None).start()
-        patch('sagify.commands.initialize._get_local_aws_profiles', return_value=['default', 'sagemaker']).start()
 
-    def test_push_with_custom_profile_default_region(self):
-        assert self.runCommands(
-            push_command=['push', '-p', 'some-profile']
-            ).exit_code == 0
-        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, 'some-profile'])
+    def tests(self):
+        for case in test_cases:
+            command_line = command_line_mock.start()
 
-    def test_push_with_custom_profile_custom_region(self):
-        assert self.runCommands(
-            push_command=['push', '-p', 'some-profile', '-r', 'some-region']
-            ).exit_code == 0
-        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', 'some-profile'])
+            try:
+                assert runCommands(case.init_cmd, case.push_cmd).exit_code == case.expected_exit_code
+                case.expected_cli_call(command_line)
+            except AssertionError as e:
+                e.args = ('Test Case: {}'.format(case.description), e.args)
+                raise
 
-    def test_push_with_default_profile_default_region(self):
-        assert self.runCommands(
-            push_command=['push']
-            ).exit_code == 0
-        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, None])
+            command_line.stop()
 
-    def test_push_with_custom_dir(self):
-        assert self.runCommands(
-            init_command=['init', '-d', 'src/'],
-            push_command=['push', '-d', 'src/', '-p', 'some-profile']
-            ).exit_code == 0
-        self.command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', None, 'some-profile'])
 
-    def test_push_with_invalid_dir(self):
-        assert self.runCommands(
-            init_command=['init', '-d', 'src/'],
-            push_command=['push', '-d', 'invalid_dir/', '-p', 'some-profile']
-            ).exit_code == -1
-        self.command_line.assert_not_called()
-
-    def runCommands(self, push_command, init_command=['init']):
-        runner = self.runner
-        with runner.isolated_filesystem():
-            runner.invoke(cli=cli, args=init_command, input='my_app\n1\n2\nus-east-1\n')
-            return runner.invoke(cli=cli, args=push_command)
+def runCommands(init_command, push_command):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        runner.invoke(cli=cli, args=init_command, input='my_app\n1\n2\nus-east-1\n')
+        return runner.invoke(cli=cli, args=push_command)

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -21,6 +21,13 @@ class PushCommandTests(TestCase):
             push_command=['push', '-p', 'some-profile']
             ).exit_code == 0
         self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-profile'])
+    
+    def test_push_with_default_profile_happy_case(self):
+        assert self.runCommands(
+            init_command=['init'],
+            push_command=['push']
+            ).exit_code == 0
+        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', None])
 
     def test_push_with_dir_arg_happy_case(self):
         assert self.runCommands(

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -15,35 +15,39 @@ class PushCommandTests(TestCase):
         self.command_line = patch('future.moves.subprocess.check_output', return_value=None).start()
         patch('sagify.commands.initialize._get_local_aws_profiles', return_value=['default', 'sagemaker']).start()
 
-    def test_push_happy_case(self):
+    def test_push_with_custom_profile_default_region(self):
         assert self.runCommands(
-            init_command=['init'],
             push_command=['push', '-p', 'some-profile']
             ).exit_code == 0
-        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-profile'])
+        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, 'some-profile'])
 
-    def test_push_with_default_profile_happy_case(self):
+    def test_push_with_custom_profile_custom_region(self):
         assert self.runCommands(
-            init_command=['init'],
+            push_command=['push', '-p', 'some-profile', '-r', 'some-region']
+            ).exit_code == 0
+        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', 'some-profile'])
+
+    def test_push_with_default_profile_default_region(self):
+        assert self.runCommands(
             push_command=['push']
             ).exit_code == 0
-        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', None])
+        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, None])
 
-    def test_push_with_dir_arg_happy_case(self):
+    def test_push_with_custom_dir(self):
         assert self.runCommands(
             init_command=['init', '-d', 'src/'],
             push_command=['push', '-d', 'src/', '-p', 'some-profile']
             ).exit_code == 0
-        self.command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', 'some-profile'])
+        self.command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', None, 'some-profile'])
 
-    def test_push_with_invalid_dir_arg_happy_case(self):
+    def test_push_with_invalid_dir(self):
         assert self.runCommands(
             init_command=['init', '-d', 'src/'],
             push_command=['push', '-d', 'invalid_dir/', '-p', 'some-profile']
             ).exit_code == -1
         self.command_line.assert_not_called()
 
-    def runCommands(self, init_command, push_command):
+    def runCommands(self, push_command, init_command=['init']):
         runner = self.runner
         with runner.isolated_filesystem():
             runner.invoke(cli=cli, args=init_command, input='my_app\n1\n2\nus-east-1\n')

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -15,19 +15,19 @@ Case = namedtuple('Case', 'description, init_cmd, push_cmd, expected_exit_code, 
 t1 = Case('default profile and region', ['init'], ['push'], 0,
           lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, None]))
 
-t2 = Case('custom profile — default region', ['init'], ['push', '-p', 'some-profile'], 0,
+t2 = Case('custom profile - default region', ['init'], ['push', '-p', 'some-profile'], 0,
           lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, 'some-profile']))
 
-t3 = Case('default profile – custom region', ['init'], ['push', '-r', 'some-region'], 0,
+t3 = Case('default profile - custom region', ['init'], ['push', '-r', 'some-region'], 0,
           lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', None]))
 
-t4 = Case('custom profile — custom region', ['init'], ['push', '-r', 'some-region', '-p', 'some-profile'], 0,
+t4 = Case('custom profile - custom region', ['init'], ['push', '-r', 'some-region', '-p', 'some-profile'], 0,
           lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', 'some-profile']))
 
-t5 = Case('custom dir — default profile and region', ['init', '-d', 'src/'], ['push', '-d', 'src/'], 0,
+t5 = Case('custom dir - default profile and region', ['init', '-d', 'src/'], ['push', '-d', 'src/'], 0,
           lambda command_line: command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', None, None]))
 
-t6 = Case('custom invalid dir — default profile and region', ['init', '-d', 'src/'], ['push', '-d', 'invalid_dir/'], -1,
+t6 = Case('custom invalid dir - default profile and region', ['init', '-d', 'src/'], ['push', '-d', 'invalid_dir/'], -1,
           lambda command_line: command_line.assert_not_called())
 
 test_cases = [t1, t2, t3, t4, t5, t6]

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -1,4 +1,5 @@
 try:
+    from unittest import TestCase
     from unittest.mock import patch
 except ImportError:
     from mock import patch
@@ -8,59 +9,35 @@ from click.testing import CliRunner
 from sagify.__main__ import cli
 
 
-def test_push_happy_case():
-    runner = CliRunner()
+class PushCommandTests(TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+        self.command_line = patch('future.moves.subprocess.check_output', return_value=None).start()
+        patch('sagify.commands.initialize._get_local_aws_profiles', return_value=['default', 'sagemaker']).start()
 
-    with patch(
-            'sagify.commands.initialize._get_local_aws_profiles',
-            return_value=['default', 'sagemaker']
-    ):
-        with patch(
-                'future.moves.subprocess.check_output',
-                return_value=None
-        ):
-            with runner.isolated_filesystem():
-                runner.invoke(cli=cli, args=['init'], input='my_app\n1\n2\nus-east-1\n')
-                result = runner.invoke(cli=cli, args=['push'])
+    def test_push_happy_case(self):
+        assert self.runCommands(
+            init_command=['init'],
+            push_command=['push', '-p', 'some-profile']
+            ).exit_code == 0
+        self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-profile'])
 
-    assert result.exit_code == 0
+    def test_push_with_dir_arg_happy_case(self):
+        assert self.runCommands(
+            init_command=['init', '-d', 'src/'],
+            push_command=['push', '-d', 'src/', '-p', 'some-profile']
+            ).exit_code == 0
+        self.command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', 'some-profile'])
 
+    def test_push_with_invalid_dir_arg_happy_case(self):
+        assert self.runCommands(
+            init_command=['init', '-d', 'src/'],
+            push_command=['push', '-d', 'invalid_dir/', '-p', 'some-profile']
+            ).exit_code == -1
+        self.command_line.assert_not_called()
 
-def test_push_with_dir_arg_happy_case():
-    runner = CliRunner()
-
-    with patch(
-            'sagify.commands.initialize._get_local_aws_profiles',
-            return_value=['default', 'sagemaker']
-    ):
-        with patch(
-                'future.moves.subprocess.check_output',
-                return_value=None
-        ):
-            with runner.isolated_filesystem():
-                runner.invoke(
-                    cli=cli, args=['init', '-d', 'src/'], input='my_app\n1\n2\nus-east-1\n'
-                )
-                result = runner.invoke(cli=cli, args=['push', '-d', 'src/'])
-
-    assert result.exit_code == 0
-
-
-def test_push_with_invalid_dir_arg_happy_case():
-    runner = CliRunner()
-
-    with patch(
-            'sagify.commands.initialize._get_local_aws_profiles',
-            return_value=['default', 'sagemaker']
-    ):
-        with patch(
-                'future.moves.subprocess.check_output',
-                return_value=None
-        ):
-            with runner.isolated_filesystem():
-                runner.invoke(
-                    cli=cli, args=['init', '-d', 'src/'], input='my_app\n1\n2\nus-east-1\n'
-                )
-                result = runner.invoke(cli=cli, args=['push', '-d', 'invalid_dir/'])
-
-    assert result.exit_code == -1
+    def runCommands(self, init_command, push_command):
+        runner = self.runner
+        with runner.isolated_filesystem():
+            runner.invoke(cli=cli, args=init_command, input='my_app\n1\n2\nus-east-1\n')
+            return runner.invoke(cli=cli, args=push_command)

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -21,7 +21,7 @@ class PushCommandTests(TestCase):
             push_command=['push', '-p', 'some-profile']
             ).exit_code == 0
         self.command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-profile'])
-    
+
     def test_push_with_default_profile_happy_case(self):
         assert self.runCommands(
             init_command=['init'],


### PR DESCRIPTION
**What**
Added support for passing an AWS profile and region dynamically to `sagify push` to override the hardcoded ones passed in `sagify init`.

Usage:

`sagify cloud --aws-profile production --aws-region us-east-1`

The options are optional to allow for the `init` based profile abd region  approach to still work.

@pm3310 I also bumped the allowed line length to 130, if you fell that's too much I'll add some newlines where needed.