### PR TITLE
Feature: IAM role and external id options for the push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,13 +301,13 @@ Pushes a Docker image to AWS Elastic Container Service
 
 #### Synopsis
 
-    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION] [--iam-role-arn IAM_ROLE]
+    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID]
 
 #### Description
 
 This command pushes an already built Docker image to AWS Elastic Container Service. Later on, AWS SageMaker will consume that image from AWS Elastic Container Service for train and serve mode.
 
-> Only one of _iam-role-arn_ and _aws_profile_ can be provided.
+> Only one of _iam-role-arn_ and _aws_profile_ can be provided. _external-id_ is ignored when no _iam-role-arn_ is provided.
 
 #### Optional Flags
 
@@ -318,6 +318,8 @@ This command pushes an already built Docker image to AWS Elastic Container Servi
 `--aws-region AWS_REGION` or `-r AWS_REGION`: The AWS region to push the image to
 
 `--aws-profile PROFILE_NAME` or `-p PROFILE_NAME`: AWS profile to use for pushing to ECR
+
+`--external-id EXTERNAL_ID` or `-e EXTERNAL_ID`: Optional external id used when using an IAM role
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -301,15 +301,19 @@ Pushes a Docker image to AWS Elastic Container Service
 
 #### Synopsis
 
-    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION]
+    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION] [--iam-role-arn IAM_ROLE]
 
 #### Description
 
 This command pushes an already built Docker image to AWS Elastic Container Service. Later on, AWS SageMaker will consume that image from AWS Elastic Container Service for train and serve mode.
 
+> Only one of _iam-role-arn_ and _aws_profile_ can be provided.
+
 #### Optional Flags
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
+
+`--iam-role-arn IAM_ROLE` or `-i IAM_ROLE`: AWS IAM role to use for pushing to ECR
 
 `--aws-region AWS_REGION` or `-r AWS_REGION`: The AWS region to push the image to
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -407,15 +407,19 @@ Pushes a Docker image to AWS Elastic Container Service
 
 #### Synopsis
 
-    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION]
+    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION] [--iam-role-arn IAM_ROLE]
     
 #### Description
 
 This command pushes an already built Docker image to AWS Elastic Container Service. Later on, AWS SageMaker will consume that image from AWS Elastic Container Service for train and serve mode.
 
+> Only one of _iam-role-arn_ and _aws_profile_ can be provided.
+
 #### Optional Flags
 
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
+
+`--iam-role-arn IAM_ROLE` or `-i IAM_ROLE`: AWS IAM role to use for pushing to ECR
 
 `--aws-region AWS_REGION` or `-r AWS_REGION`: The AWS region to push the image to
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -407,13 +407,13 @@ Pushes a Docker image to AWS Elastic Container Service
 
 #### Synopsis
 
-    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION] [--iam-role-arn IAM_ROLE]
+    sagify push [--dir SRC_DIR] [--aws-profile PROFILE_NAME] [--aws-region AWS_REGION] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID]
     
 #### Description
 
 This command pushes an already built Docker image to AWS Elastic Container Service. Later on, AWS SageMaker will consume that image from AWS Elastic Container Service for train and serve mode.
 
-> Only one of _iam-role-arn_ and _aws_profile_ can be provided.
+> Only one of _iam-role-arn_ and _aws_profile_ can be provided. _external-id_ is ignored when no _iam-role-arn_ is provided.
 
 #### Optional Flags
 
@@ -424,6 +424,8 @@ This command pushes an already built Docker image to AWS Elastic Container Servi
 `--aws-region AWS_REGION` or `-r AWS_REGION`: The AWS region to push the image to
 
 `--aws-profile PROFILE_NAME` or `-p PROFILE_NAME`: AWS profile to use for pushing to ECR
+
+`--external-id EXTERNAL_ID` or `-e EXTERNAL_ID`: Optional external id used when using an IAM role
 
 #### Example
 

--- a/sagify/api/push.py
+++ b/sagify/api/push.py
@@ -8,7 +8,7 @@ from future.moves import subprocess
 from sagify.log import logger
 
 
-def push(dir, docker_tag, aws_region, iam_role_arn, aws_profile):
+def push(dir, docker_tag, aws_region, iam_role_arn, aws_profile, external_id):
     """
     Push Docker image to AWS ECS
 
@@ -17,9 +17,10 @@ def push(dir, docker_tag, aws_region, iam_role_arn, aws_profile):
     :param aws_region: [str], the AWS region to push the image to
     :param iam_role_arn: [str], the AWS role used to push the image to ECR
     :param aws_profile: [str], the AWS profile used to push the image to ECR
+    :param external_id: [str], Optional external id used when using an IAM role
     """
-    sagify_module_path = os.path.relpath(os.path.join(dir, 'sagify/'))
 
+    sagify_module_path = os.path.relpath(os.path.join(dir, 'sagify/'))
     push_script_path = os.path.join(sagify_module_path, 'push.sh')
 
     if not os.path.isfile(push_script_path):
@@ -27,6 +28,14 @@ def push(dir, docker_tag, aws_region, iam_role_arn, aws_profile):
 
     aws_region = "" if aws_region is None else aws_region
     aws_profile = "" if aws_profile is None else aws_profile
+    external_id = "" if external_id is None else external_id
     iam_role_arn = "" if iam_role_arn is None else iam_role_arn
-    output = subprocess.check_output(["{}".format(push_script_path), docker_tag, aws_region, iam_role_arn, aws_profile])
+
+    output = subprocess.check_output([
+                                     "{}".format(push_script_path),
+                                     docker_tag,
+                                     aws_region,
+                                     iam_role_arn,
+                                     aws_profile,
+                                     external_id])
     logger.debug(output)

--- a/sagify/api/push.py
+++ b/sagify/api/push.py
@@ -8,13 +8,14 @@ from future.moves import subprocess
 from sagify.log import logger
 
 
-def push(dir, docker_tag, aws_region, aws_profile):
+def push(dir, docker_tag, aws_region, iam_role_arn, aws_profile):
     """
     Push Docker image to AWS ECS
 
     :param dir: [str], source root directory
     :param docker_tag: [str], the Docker tag for the image
     :param aws_region: [str], the AWS region to push the image to
+    :param iam_role_arn: [str], the AWS role used to push the image to ECR
     :param aws_profile: [str], the AWS profile used to push the image to ECR
     """
     sagify_module_path = os.path.relpath(os.path.join(dir, 'sagify/'))
@@ -24,5 +25,5 @@ def push(dir, docker_tag, aws_region, aws_profile):
     if not os.path.isfile(push_script_path):
         raise ValueError("This is not a sagify directory: {}".format(dir))
 
-    output = subprocess.check_output(["{}".format(push_script_path), docker_tag, aws_region, aws_profile])
+    output = subprocess.check_output(["{}".format(push_script_path), docker_tag, aws_region, iam_role_arn, aws_profile])
     logger.debug(output)

--- a/sagify/commands/push.py
+++ b/sagify/commands/push.py
@@ -16,9 +16,10 @@ click.disable_unicode_literals_warning = True
 @click.command()
 @click.option(u"-d", u"--dir", required=False, default='.', help="Path to sagify module")
 @click.option(u"-r", u"--aws-region", required=False, help="The AWS region to push the image to")
+@click.option(u"-i", u"--iam-role-arn", required=False, help="The AWS role to use for the push command")
 @click.option(u"-p", u"--aws-profile", required=False, help="The AWS profile to use for the push command")
 @click.pass_obj
-def push(obj, dir, aws_region, aws_profile):
+def push(obj, dir, aws_region, iam_role_arn, aws_profile):
     """
     Command to push Docker image to AWS ECS
     """
@@ -27,8 +28,17 @@ def push(obj, dir, aws_region, aws_profile):
         "Started pushing Docker image to AWS ECS. It will take some time. Please, be patient...\n"
     )
 
+    if iam_role_arn is not None and aws_profile is not None:
+        logger.error('Only one of iam-role-arn and aws-profile can be used.')
+        sys.exit(2)
+
     try:
-        api_push.push(dir=dir, docker_tag=obj['docker_tag'], aws_region=aws_region, aws_profile=aws_profile)
+        api_push.push(
+            dir=dir,
+            docker_tag=obj['docker_tag'],
+            aws_region=aws_region,
+            iam_role_arn=iam_role_arn,
+            aws_profile=aws_profile)
 
         logger.info("Docker image pushed to ECS successfully!")
     except ValueError:

--- a/sagify/commands/push.py
+++ b/sagify/commands/push.py
@@ -18,8 +18,9 @@ click.disable_unicode_literals_warning = True
 @click.option(u"-r", u"--aws-region", required=False, help="The AWS region to push the image to")
 @click.option(u"-i", u"--iam-role-arn", required=False, help="The AWS role to use for the push command")
 @click.option(u"-p", u"--aws-profile", required=False, help="The AWS profile to use for the push command")
+@click.option(u"-e", u"--external-id", required=False, help="Optional external id used when using an IAM role")
 @click.pass_obj
-def push(obj, dir, aws_region, iam_role_arn, aws_profile):
+def push(obj, dir, aws_region, iam_role_arn, aws_profile, external_id):
     """
     Command to push Docker image to AWS ECS
     """
@@ -38,7 +39,8 @@ def push(obj, dir, aws_region, iam_role_arn, aws_profile):
             docker_tag=obj['docker_tag'],
             aws_region=aws_region,
             iam_role_arn=iam_role_arn,
-            aws_profile=aws_profile)
+            aws_profile=aws_profile,
+            external_id=external_id)
 
         logger.info("Docker image pushed to ECS successfully!")
     except ValueError:

--- a/sagify/template/{{ cookiecutter.module_slug }}/push.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/push.sh
@@ -5,10 +5,13 @@ tag=$1
 region=$2
 role=$3
 profile=$4
+external_id=$5
 
 if [[ ! -z "$role" ]]; then 
     aws configure set profile.${role}.role_arn ${role}
-    aws configure set profile.${role}.external_id SomeExternalID
+    if [[ ! -z "$external_id" ]]; then 
+        aws configure set profile.${role}.external_id ${external_id}
+    fi
     aws configure set profile.${role}.source_profile default
     profile=${role}
 elif [ -z "$profile" ]; then 

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -12,31 +12,35 @@ from sagify.__main__ import cli
 
 Case = namedtuple('Case', 'description, init_cmd, push_cmd, expected_exit_code, expected_cli_call')
 
-t1 = Case('sagify push', ['init'], ['push'], 0,
-          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', '', '', '']))
+t1 = Case('t1: sagify push', ['init'], ['push'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', '', '', '', '']))
 
-t2 = Case('sagify push -p profile', ['init'], ['push', '-p', 'some-profile'], 0,
-          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', '', '', 'some-profile']))
+t2 = Case('t2: sagify push -p profile', ['init'], ['push', '-p', 'some-profile'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', '', '', 'some-profile', '']))
 
-t3 = Case('sagify push -r region', ['init'], ['push', '-r', 'some-region'], 0,
-          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', '', '']))
+t3 = Case('t3: sagify push -r region', ['init'], ['push', '-r', 'some-region'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', '', '', '']))
 
-t4 = Case('sagify push -r region -p profile', ['init'], ['push', '-r', 'some-region', '-p', 'prof'], 0,
-          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', '', 'prof']))
+t4 = Case('t4: sagify push -r region -p profile', ['init'], ['push', '-r', 'some-region', '-p', 'prof'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', '', 'prof', '']))
 
-t5 = Case('sagify push -d dir/', ['init', '-d', 'src/'], ['push', '-d', 'src/'], 0,
-          lambda command_line: command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', '', '', '']))
+t5 = Case('t5: sagify push -d dir/', ['init', '-d', 'src/'], ['push', '-d', 'src/'], 0,
+          lambda command_line: command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', '', '', '', '']))
 
-t6 = Case('sagify push -d invalid_dir/', ['init', '-d', 'src/'], ['push', '-d', 'invalid_dir/'], -1,
+t6 = Case('t6: sagify push -d invalid_dir/', ['init', '-d', 'src/'], ['push', '-d', 'invalid_dir/'], -1,
           lambda command_line: command_line.assert_not_called())
 
-t7 = Case('sagify push -i aws-role', ['init'], ['push', '-i', 'some-role-arn'], 0,
-          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', '', 'some-role-arn', '']))
+t7 = Case('t7: sagify push -i aws-role', ['init'], ['push', '-i', 'some-role-arn'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', '', 'some-role-arn', '', '']))
 
-t8 = Case('sagify -p profile -i aws-role', ['init'], ['push', '-i', 'some-role-arn', '-p', 'some-profile'], 2,
+t8 = Case('t8: sagify -p profile -i aws-role', ['init'], ['push', '-i', 'some-role-arn', '-p', 'some-profile'], 2,
           lambda command_line: command_line.assert_not_called())
 
-test_cases = [t1, t2, t3, t4, t5, t6, t7, t8]
+t9 = Case('t9: sagify push -i aws-role -e some-id', ['init'], ['push', '-i', 'some-role-arn', '-e', 'some-id'], 0,
+          lambda command_line:
+          command_line.assert_called_once_with(['sagify/push.sh', 'latest', '', 'some-role-arn', '', 'some-id']))
+
+test_cases = [t1, t2, t3, t4, t5, t6, t7, t8, t9]
 
 # Mocks
 command_line_mock = patch('future.moves.subprocess.check_output', return_value=None)

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -12,25 +12,31 @@ from sagify.__main__ import cli
 
 Case = namedtuple('Case', 'description, init_cmd, push_cmd, expected_exit_code, expected_cli_call')
 
-t1 = Case('default profile and region', ['init'], ['push'], 0,
-          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, None]))
+t1 = Case('sagify push', ['init'], ['push'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, None, None]))
 
-t2 = Case('custom profile - default region', ['init'], ['push', '-p', 'some-profile'], 0,
-          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, 'some-profile']))
+t2 = Case('sagify push -p profile', ['init'], ['push', '-p', 'some-profile'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, None, 'some-profile']))
 
-t3 = Case('default profile - custom region', ['init'], ['push', '-r', 'some-region'], 0,
-          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', None]))
+t3 = Case('sagify push -r region', ['init'], ['push', '-r', 'some-region'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', None, None]))
 
-t4 = Case('custom profile - custom region', ['init'], ['push', '-r', 'some-region', '-p', 'some-profile'], 0,
-          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', 'some-profile']))
+t4 = Case('sagify push -r region -p profile', ['init'], ['push', '-r', 'some-region', '-p', 'prof'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', 'some-region', None, 'prof']))
 
-t5 = Case('custom dir - default profile and region', ['init', '-d', 'src/'], ['push', '-d', 'src/'], 0,
-          lambda command_line: command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', None, None]))
+t5 = Case('sagify push -d dir/', ['init', '-d', 'src/'], ['push', '-d', 'src/'], 0,
+          lambda command_line: command_line.assert_called_once_with(['src/sagify/push.sh', 'latest', None, None, None]))
 
-t6 = Case('custom invalid dir - default profile and region', ['init', '-d', 'src/'], ['push', '-d', 'invalid_dir/'], -1,
+t6 = Case('sagify push -d invalid_dir/', ['init', '-d', 'src/'], ['push', '-d', 'invalid_dir/'], -1,
           lambda command_line: command_line.assert_not_called())
 
-test_cases = [t1, t2, t3, t4, t5, t6]
+t7 = Case('sagify push -i aws-role', ['init'], ['push', '-i', 'some-role-arn'], 0,
+          lambda command_line: command_line.assert_called_once_with(['sagify/push.sh', 'latest', None, 'some-role-arn', None]))
+
+t8 = Case('sagify -p profile -i aws-role', ['init'], ['push', '-i', 'some-role-arn', '-p', 'some-profile'], 2,
+          lambda command_line: command_line.assert_not_called())
+
+test_cases = [t1, t2, t3, t4, t5, t6, t7, t8]
 
 # Mocks
 command_line_mock = patch('future.moves.subprocess.check_output', return_value=None)


### PR DESCRIPTION
**What**

Added two new options to `sagify push`: *iam_role_arn* and *external_id* for use cases whereby a role is preferred over a profile. They are useful in CI environments mostly for cross-account (including third party accounts) cases where the account we're pushing to is not the one the  *AWS* profile we're currently using is under.