### PR TITLE
Feature: Support for using AWS IAM role for cloud train command

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Executes a Docker image in train mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS]
+    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID]
 
 #### Description
 
@@ -388,6 +388,10 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 `--time-out TIME_OUT_IN_SECS` or `-s TIME_OUT_IN_SECS`: Time-out in seconds (default: 24 * 60 * 60)
 
 `--aws-tags TAGS` or `-a TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+
+`--iam-role-arn IAM_ROLE` or `-r IAM_ROLE`: AWS IAM role to use for training with *SageMaker*
+
+`--external-id EXTERNAL_ID` or `-x EXTERNAL_ID`: Optional external id used when using an IAM role
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -469,7 +469,7 @@ Executes a Docker image in train mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS]
+    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID]
 
 #### Description
 
@@ -494,6 +494,10 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 `--time-out TIME_OUT_IN_SECS` or `-s TIME_OUT_IN_SECS`: Time-out in seconds (default: 24 * 60 * 60)
 
 `--aws-tags TAGS` or `-a TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+
+`--iam-role-arn IAM_ROLE` or `-r IAM_ROLE`: AWS IAM role to use for training with *SageMaker*
+
+`--external-id EXTERNAL_ID` or `-x EXTERNAL_ID`: Optional external id used when using an IAM role
 
 #### Example
 

--- a/sagify/api/cloud.py
+++ b/sagify/api/cloud.py
@@ -51,6 +51,8 @@ def train(
         volume_size,
         time_out,
         docker_tag,
+        aws_role,
+        external_id,
         tags=None
 ):
     """
@@ -65,6 +67,8 @@ def train(
     :param volume_size: [int], size in GB of the EBS volume
     :param time_out: [int], time-out in seconds
     :param docker_tag: [str], the Docker tag for the image
+    :param aws_role: [str], the AWS role assumed by SageMaker while training
+    :param external_id: [str], Optional external id used when using an IAM role
     :param tags: [optional[list[dict]], default: None], List of tags for labeling a training
         job. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html. Example:
 
@@ -79,12 +83,11 @@ def train(
             },
             ...
         ]
-
     :return: [str], S3 model location
     """
     config = _read_config(dir)
     hyperparams_dict = _read_hyperparams_config(hyperparams_file) if hyperparams_file else None
-    sage_maker_client = sagemaker.SageMakerClient(config.aws_profile, config.aws_region)
+    sage_maker_client = sagemaker.SageMakerClient(config.aws_profile, config.aws_region, aws_role, external_id)
 
     image_name = config.image_name+':'+docker_tag
 

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -92,7 +92,7 @@ def upload_data(dir, input_dir, s3_dir):
          'https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.'
 )
 @click.option(
-    u"-i",
+    u"-r",
     u"--iam-role-arn",
     required=False,
     help="The AWS role to use for the push command"

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -98,7 +98,7 @@ def upload_data(dir, input_dir, s3_dir):
     help="The AWS role to use for the push command"
 )
 @click.option(
-    u"-e",
+    u"-x",
     u"--external-id",
     required=False,
     help="Optional external id used when using an IAM role"

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -114,7 +114,7 @@ def train(
         volume_size,
         time_out,
         aws_tags,
-        aws_role,
+        iam_role_arn,
         external_id
 ):
     """
@@ -134,7 +134,7 @@ def train(
             time_out=time_out,
             docker_tag=obj['docker_tag'],
             tags=aws_tags,
-            aws_role=aws_role,
+            aws_role=iam_role_arn,
             external_id=external_id
         )
 

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -91,6 +91,18 @@ def upload_data(dir, input_dir, s3_dir):
     help='Tags for labeling a training job of the form "tag1=value1;tag2=value2". For more, see '
          'https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.'
 )
+@click.option(
+    u"-i",
+    u"--iam-role-arn",
+    required=False,
+    help="The AWS role to use for the push command"
+)
+@click.option(
+    u"-e",
+    u"--external-id",
+    required=False,
+    help="Optional external id used when using an IAM role"
+)
 @click.pass_obj
 def train(
         obj,
@@ -101,7 +113,9 @@ def train(
         ec2_type,
         volume_size,
         time_out,
-        aws_tags
+        aws_tags,
+        aws_role,
+        external_id
 ):
     """
     Command to train ML model(s) on SageMaker
@@ -119,7 +133,9 @@ def train(
             volume_size=volume_size,
             time_out=time_out,
             docker_tag=obj['docker_tag'],
-            tags=aws_tags
+            tags=aws_tags,
+            aws_role=aws_role,
+            external_id=external_id
         )
 
         logger.info("Training on SageMaker succeeded")

--- a/sagify/sagemaker/sagemaker.py
+++ b/sagify/sagemaker/sagemaker.py
@@ -7,12 +7,35 @@ from six.moves.urllib.parse import urlparse
 
 import boto3
 
+from sagify.log import logger
+
 
 class SageMakerClient(object):
-    def __init__(self, aws_profile, aws_region):
-        self.boto_session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
+    def __init__(self, aws_profile, aws_region, aws_role=None, external_id=None):
+
+        if aws_role and external_id:
+            logger.info("An IAM role and corresponding external id were provided. Attempting to assume that role...")
+
+            sts_client = boto3.client('sts')
+            assumedRoleObject = sts_client.assume_role(
+                RoleArn=aws_role,
+                RoleSessionName="SagifySession",
+                ExternalId=external_id
+            )
+
+            credentials = assumedRoleObject['Credentials']
+            self.boto_session = boto3.Session(
+                aws_access_key_id=credentials['AccessKeyId'],
+                aws_secret_access_key=credentials['SecretAccessKey'],
+                aws_session_token=credentials['SessionToken'],
+                region_name=aws_region
+            )
+        else:
+            logger.info("No IAM role provided. Using profile {} instead.".format(aws_profile))
+            self.boto_session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
+
         self.sagemaker_session = sage.Session(boto_session=self.boto_session)
-        self.role = sage.get_execution_role(self.sagemaker_session)
+        self.role = sage.get_execution_role(self.sagemaker_session) if aws_role is None else aws_role
 
     def upload_data(self, input_dir, s3_dir):
         """

--- a/tests/commands/test_cloud.py
+++ b/tests/commands/test_cloud.py
@@ -165,6 +165,53 @@ class TestTrain(object):
 
         assert result.exit_code == 0
 
+    def test_train_with_role_and_external_id_happy_case(self):
+        runner = CliRunner()
+
+        with patch(
+                'sagify.commands.initialize._get_local_aws_profiles',
+                return_value=['default', 'sagify']
+        ):
+            with patch.object(
+                    sagify.config.config.ConfigManager,
+                    'get_config',
+                    lambda _: Config(
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1'
+                    )
+            ):
+                with patch(
+                        'sagify.sagemaker.sagemaker.SageMakerClient'
+                ) as mocked_sage_maker_client:
+                    instance = mocked_sage_maker_client.return_value
+                    with runner.isolated_filesystem():
+                        runner.invoke(cli=cli, args=['init'], input='my_app\n1\n2\nus-east-1\n')
+                        result = runner.invoke(
+                            cli=cli,
+                            args=[
+                                'cloud', 'train',
+                                '-i', 's3://bucket/input',
+                                '-o', 's3://bucket/output',
+                                '-e', 'ml.c4.2xlarge',
+                                '-r', 'some iam role',
+                                '-x', 'some external id'
+                            ]
+                        )
+
+                        assert instance.train.call_count == 1
+                        instance.train.assert_called_with(
+                            image_name='sagemaker-img:latest',
+                            input_s3_data_location='s3://bucket/input',
+                            train_instance_count=1,
+                            train_instance_type='ml.c4.2xlarge',
+                            train_volume_size=30,
+                            train_max_run=24 * 60 * 60,
+                            output_path='s3://bucket/output',
+                            hyperparameters=None,
+                            tags=None
+                        )
+
+        assert result.exit_code == 0
+
     def test_train_with_tags_arg_happy_case(self):
         runner = CliRunner()
 


### PR DESCRIPTION
**What**

Users can now pass two new arguments to `sagify cloud train`: *iam-role-arn* and *external-id*.

These are useful when working in cross-account scenarios and third parties.

**Usage**

`sagify cloud train -i s3-input --o s3-output -e ec2-type --iam-role-arn role-arn --external-id ext-id`

If a role and external id are passed, we attempt to assume that role instead of using the local profile hardcoded via `init`.

**Tests**
Added test covering the new case.