### PR TITLE
Easier local development

### DIFF
--- a/sagify/template/{{ cookiecutter.module_slug }}/Dockerfile
+++ b/sagify/template/{{ cookiecutter.module_slug }}/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /opt/program/${target_dir_name}
 # Here we get all python packages.
 RUN pip install flask gevent gunicorn future
 RUN pip install -r ../sagify-requirements.txt && rm -rf /root/.cache
-RUN sudo apt-get purge --auto-remove git
+RUN apt-get purge --auto-remove git
 
 COPY ${module_path} /opt/program/${target_dir_name}
 

--- a/sagify/template/{{ cookiecutter.module_slug }}/Dockerfile
+++ b/sagify/template/{{ cookiecutter.module_slug }}/Dockerfile
@@ -1,22 +1,17 @@
-# Build an image that can do training and inference in SageMaker
-# This is an image that uses the nginx, gunicorn, flask stack
-# for serving inferences in a stable way.
-
 FROM python:{{ cookiecutter.python_version }}-slim-stretch
 
-MAINTAINER Amazon AI <support@kenza.ai>
-
+MAINTAINER Kenza AI <support@kenza.ai>
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
          nginx \
          ca-certificates \
          g++ \
+         git \
     && rm -rf /var/lib/apt/lists/*
 
-# Set some environment variables. PYTHONUNBUFFERED keeps Python from buffering our standard
-# output stream, which means that logs can be delivered to the user quickly. PYTHONDONTWRITEBYTECODE
-# keeps Python from writing the .pyc files which are unnecessary in this case. We also update
-# PATH so that the train and serve programs are found when the container is invoked.
+# PYTHONUNBUFFERED keeps Python from buffering the standard
+# output stream, which means that logs can be delivered to the user quickly. 
+# PYTHONDONTWRITEBYTECODE keeps Python from writing the .pyc files which are unnecessary in this case. 
 
 ENV PYTHONUNBUFFERED=TRUE
 ENV PYTHONDONTWRITEBYTECODE=TRUE
@@ -32,6 +27,7 @@ WORKDIR /opt/program/${target_dir_name}
 # Here we get all python packages.
 RUN pip install flask gevent gunicorn future
 RUN pip install -r ../sagify-requirements.txt && rm -rf /root/.cache
+RUN sudo apt-get purge --auto-remove git
 
 COPY ${module_path} /opt/program/${target_dir_name}
 

--- a/sagify/template/{{ cookiecutter.module_slug }}/Dockerfile
+++ b/sagify/template/{{ cookiecutter.module_slug }}/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /opt/program/${target_dir_name}
 # Here we get all python packages.
 RUN pip install flask gevent gunicorn future
 RUN pip install -r ../sagify-requirements.txt && rm -rf /root/.cache
-RUN apt-get purge --auto-remove git
+RUN apt-get -y purge --auto-remove git
 
 COPY ${module_path} /opt/program/${target_dir_name}
 


### PR DESCRIPTION
Manually testing modifications in a PR can get difficult.

The difficulty comes from the fact that the Dockerfile cannot build **local packages** or **packages from forks** in its current state.

For example, to test my PR at #51 was working as intended I had to point requirements.txt's *sagify* entry to my fork like so:

`-e git+git://github.com/ilazakis/sagify.git@feature/iam-role-for-train-deploy-command#egg=sagify`

This works fine for `pip install -r requirements.txt` but the `sagify build` step fails because the *Dockerfile* is not "git aware". 

To fix that, one can manually bake *git* in the image with the rest (*nginx, ca-certificates* etc). We obviously don't need it there post-build, so I [added a step to remove it](https://github.com/Kenza-AI/sagify/pull/52/files#diff-fe7366212b2b5e5af01707b570463b4cR30) and its dependencies after we're done with it, viz. after the `pip install` step.

A similar approach could take care of installing a local package instead of a fork by copying the sagify package folder in the `Dockerfile` root and cleaning up post-installation if needed.
