### PR TITLE
Added support for prefixing the SageMaker job name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Executes a Docker image in train mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID]
+    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID] [--base-job-name BASE_JOB_NAME]
 
 #### Description
 
@@ -392,6 +392,8 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 `--iam-role-arn IAM_ROLE` or `-r IAM_ROLE`: AWS IAM role to use for training with *SageMaker*
 
 `--external-id EXTERNAL_ID` or `-x EXTERNAL_ID`: Optional external id used when using an IAM role
+
+`--base-job-name BASE_JOB_NAME` or `-n BASE_JOB_NAME`: Optional prefix for the SageMaker training job
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -469,7 +469,7 @@ Executes a Docker image in train mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID]
+    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID] [--base-job-name BASE_JOB_NAME]
 
 #### Description
 
@@ -498,6 +498,8 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 `--iam-role-arn IAM_ROLE` or `-r IAM_ROLE`: AWS IAM role to use for training with *SageMaker*
 
 `--external-id EXTERNAL_ID` or `-x EXTERNAL_ID`: Optional external id used when using an IAM role
+
+`--base-job-name BASE_JOB_NAME` or `-n BASE_JOB_NAME`: Optional prefix for the SageMaker training job
 
 #### Example
 

--- a/sagify/api/cloud.py
+++ b/sagify/api/cloud.py
@@ -53,6 +53,7 @@ def train(
         docker_tag,
         aws_role,
         external_id,
+        base_job_name,
         tags=None
 ):
     """
@@ -69,6 +70,7 @@ def train(
     :param docker_tag: [str], the Docker tag for the image
     :param aws_role: [str], the AWS role assumed by SageMaker while training
     :param external_id: [str], Optional external id used when using an IAM role
+    :param base_job_name: [str], Optional prefix for the SageMaker training job
     :param tags: [optional[list[dict]], default: None], List of tags for labeling a training
         job. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html. Example:
 
@@ -100,6 +102,7 @@ def train(
         train_max_run=time_out,
         output_path=output_s3_dir,
         hyperparameters=hyperparams_dict,
+        base_job_name=base_job_name,
         tags=tags
     )
 

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -103,6 +103,13 @@ def upload_data(dir, input_dir, s3_dir):
     required=False,
     help="Optional external id used when using an IAM role"
 )
+@click.option(
+    u"-n",
+    u"--base-job-name",
+    required=False,
+    help="Optional prefix for the SageMaker training job."
+    "If not specified, the estimator generates a default job name, based on the training image name and current timestamp."
+)
 @click.pass_obj
 def train(
         obj,
@@ -115,7 +122,8 @@ def train(
         time_out,
         aws_tags,
         iam_role_arn,
-        external_id
+        external_id,
+        base_job_name
 ):
     """
     Command to train ML model(s) on SageMaker
@@ -135,7 +143,8 @@ def train(
             docker_tag=obj['docker_tag'],
             tags=aws_tags,
             aws_role=iam_role_arn,
-            external_id=external_id
+            external_id=external_id,
+            base_job_name=base_job_name
         )
 
         logger.info("Training on SageMaker succeeded")

--- a/sagify/sagemaker/sagemaker.py
+++ b/sagify/sagemaker/sagemaker.py
@@ -60,6 +60,7 @@ class SageMakerClient(object):
             train_max_run,
             output_path,
             hyperparameters,
+            base_job_name,
             tags=None
     ):
         """
@@ -74,6 +75,7 @@ class SageMakerClient(object):
         result (model artifacts and output files)
         :param hyperparameters: [dict], Dictionary containing the hyperparameters to initialize
         this estimator with
+        :param base_job_name: [str], Optional prefix for the SageMaker training job.
         :param tags: [optional[list[dict]], default: None], List of tags for labeling a training
         job. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html. Example:
 
@@ -103,6 +105,7 @@ class SageMakerClient(object):
             input_mode='File',
             output_path=output_path,
             hyperparameters=hyperparameters,
+            base_job_name=base_job_name,
             sagemaker_session=self.sagemaker_session
         )
         if tags:

--- a/tests/commands/test_cloud.py
+++ b/tests/commands/test_cloud.py
@@ -160,12 +160,13 @@ class TestTrain(object):
                             train_max_run=24 * 60 * 60,
                             output_path='s3://bucket/output',
                             hyperparameters=None,
+                            base_job_name=None,
                             tags=None
                         )
 
         assert result.exit_code == 0
 
-    def test_train_with_role_and_external_id_happy_case(self):
+    def test_train_with_job_name_and_role_and_external_id_happy_case(self):
         runner = CliRunner()
 
         with patch(
@@ -193,7 +194,8 @@ class TestTrain(object):
                                 '-o', 's3://bucket/output',
                                 '-e', 'ml.c4.2xlarge',
                                 '-r', 'some iam role',
-                                '-x', 'some external id'
+                                '-x', 'some external id',
+                                '-n', 'some job name prefix'
                             ]
                         )
 
@@ -207,6 +209,7 @@ class TestTrain(object):
                             train_max_run=24 * 60 * 60,
                             output_path='s3://bucket/output',
                             hyperparameters=None,
+                            base_job_name='some job name prefix',
                             tags=None
                         )
 
@@ -253,6 +256,7 @@ class TestTrain(object):
                             train_max_run=24 * 60 * 60,
                             output_path='s3://bucket/output',
                             hyperparameters=None,
+                            base_job_name=None,
                             tags=[
                                 {
                                     'Key': 'key1',
@@ -308,6 +312,7 @@ class TestTrain(object):
                             train_max_run=24 * 60 * 60,
                             output_path='s3://bucket/output',
                             hyperparameters=None,
+                            base_job_name=None,
                             tags=None
                         )
 
@@ -357,6 +362,7 @@ class TestTrain(object):
                             train_max_run=24 * 60 * 60,
                             output_path='s3://bucket/output',
                             hyperparameters=None,
+                            base_job_name=None,
                             tags=None
                         )
 

--- a/tests/sagemaker/test_sagemaker.py
+++ b/tests/sagemaker/test_sagemaker.py
@@ -87,7 +87,8 @@ def test_train_happy_case():
                             train_volume_size=30,
                             train_max_run=60,
                             output_path='s3://bucket/output',
-                            hyperparameters={'n_estimator': 3}
+                            hyperparameters={'n_estimator': 3},
+                            base_job_name="Some-job-name-prefix",
                         )
                         mocked_sagemaker_estimator.assert_called_with(
                             image_name='image-full-name',
@@ -97,6 +98,7 @@ def test_train_happy_case():
                             train_volume_size=30,
                             train_max_run=60,
                             input_mode='File',
+                            base_job_name="Some-job-name-prefix",
                             output_path='s3://bucket/output',
                             hyperparameters={'n_estimator': 3},
                             sagemaker_session=sagemaker_session_instance


### PR DESCRIPTION
**What**
Added support for prefixing the `SageMaker` training job name.

*AWS* [names all training jobs](https://sagemaker.readthedocs.io/en/latest/estimators.html#sagemaker.estimator.Estimator) by combining the *docker* image name and a timestamp e.g. `sage-img-2018-11-15-17-28-13-642`.

This adds the ability to prefix the training job name with a user provided literal instead of the `docker` image name.

This is useful for querying jobs following a specific naming convention or when filtering or batch processing jobs for analysis offline on a backend system.

**Usage**
`sagify cloud train -d src/ -i s3://my-bucket/training-data/ -o s3://my-bucket/output/ -e ml.m4.xlarge -h local/path/to/hyperparams.json -v 60 -t 86400 --base-job-name MY_JOB_NAME`

This will result in a job named `MY_JOB_NAME-2018-11-15-17-28-13-642`