### PR TITLE
Feature/iam role for cloud deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Executes a Docker image in serve mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud deploy --s3-model-location S3_LOCATION_TO_MODEL_TAR_GZ --num-instance NUMBER_OF_EC2_INSTANCES --ec2-type EC2_TYPE [--dir SRC_DIR] [--aws-tags TAGS]
+    sagify cloud deploy --s3-model-location S3_LOCATION_TO_MODEL_TAR_GZ --num-instance NUMBER_OF_EC2_INSTANCES --ec2-type EC2_TYPE [--dir SRC_DIR] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID]
 
 #### Description
 
@@ -425,6 +425,10 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
 
 `--aws-tags TAGS` or `-a TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+
+`--iam-role-arn IAM_ROLE` or `-r IAM_ROLE`: AWS IAM role to use for deploying with *SageMaker*
+
+`--external-id EXTERNAL_ID` or `-x EXTERNAL_ID`: Optional external id used when using an IAM role
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -512,7 +512,7 @@ Executes a Docker image in serve mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud deploy --s3-model-location S3_LOCATION_TO_MODEL_TAR_GZ --num-instance NUMBER_OF_EC2_INSTANCES --ec2-type EC2_TYPE [--dir SRC_DIR] [--aws-tags TAGS]
+    sagify cloud deploy --s3-model-location S3_LOCATION_TO_MODEL_TAR_GZ --num-instance NUMBER_OF_EC2_INSTANCES --ec2-type EC2_TYPE [--dir SRC_DIR] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID]
 
 #### Description
 
@@ -531,6 +531,10 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 `--dir SRC_DIR` or `-d SRC_DIR`: Directory where sagify module resides
 
 `--aws-tags TAGS` or `-a TAGS`: Tags for labeling a training job of the form `tag1=value1;tag2=value2`. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+
+`--iam-role-arn IAM_ROLE` or `-r IAM_ROLE`: AWS IAM role to use for deploying with *SageMaker*
+
+`--external-id EXTERNAL_ID` or `-x EXTERNAL_ID`: Optional external id used when using an IAM role
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -481,7 +481,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT` or `o S3_LOCATION_TO_SAVE_OUTPUT`: S3 location to save output (models, reports, etc). Make sure that the output bucket already exists. Any not existing key prefix will be created by sagify.
 
-`--ec2-type EC2_TYPE` or `e EC2_TYPE`: ec2 type. Refer to <https://aws.amazon.com/sagemaker/pricing/instance-types/>
+`--ec2-type EC2_TYPE` or `-e EC2_TYPE`: ec2 type. Refer to <https://aws.amazon.com/sagemaker/pricing/instance-types/>
 
 #### Optional Flags
 
@@ -524,7 +524,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--num-instances NUMBER_OF_EC2_INSTANCES` or `n NUMBER_OF_EC2_INSTANCES`: Number of ec2 instances
 
-`--ec2-type EC2_TYPE` or `e EC2_TYPE`: ec2 type. Refer to https://aws.amazon.com/sagemaker/pricing/instance-types/
+`--ec2-type EC2_TYPE` or `-e EC2_TYPE`: ec2 type. Refer to https://aws.amazon.com/sagemaker/pricing/instance-types/
 
 #### Optional Flags
 

--- a/sagify/api/cloud.py
+++ b/sagify/api/cloud.py
@@ -104,7 +104,7 @@ def train(
     )
 
 
-def deploy(dir, s3_model_location, num_instances, ec2_type, docker_tag, tags=None):
+def deploy(dir, s3_model_location, num_instances, ec2_type, docker_tag, aws_role=None, external_id=None, tags=None):
     """
     Deploys ML model(s) on SageMaker
 
@@ -114,6 +114,8 @@ def deploy(dir, s3_model_location, num_instances, ec2_type, docker_tag, tags=Non
     :param ec2_type: [str], ec2 instance type. Refer to:
     https://aws.amazon.com/sagemaker/pricing/instance-types/
     :param docker_tag: [str], the Docker tag for the image
+    :param aws_role: [str], the AWS role assumed by SageMaker while deploying
+    :param external_id: [str], Optional external id used when using an IAM role
     :param tags: [optional[list[dict]], default: None], List of tags for labeling a training
         job. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html. Example:
 
@@ -133,8 +135,8 @@ def deploy(dir, s3_model_location, num_instances, ec2_type, docker_tag, tags=Non
     """
     config = _read_config(dir)
     image_name = config.image_name+':'+docker_tag
-
-    sage_maker_client = sagemaker.SageMakerClient(config.aws_profile, config.aws_region)
+    
+    sage_maker_client = sagemaker.SageMakerClient(config.aws_profile, config.aws_region, aws_role, external_id)
     return sage_maker_client.deploy(
         image_name=image_name,
         s3_model_location=s3_model_location,

--- a/sagify/api/cloud.py
+++ b/sagify/api/cloud.py
@@ -135,7 +135,7 @@ def deploy(dir, s3_model_location, num_instances, ec2_type, docker_tag, aws_role
     """
     config = _read_config(dir)
     image_name = config.image_name+':'+docker_tag
-    
+
     sage_maker_client = sagemaker.SageMakerClient(config.aws_profile, config.aws_region, aws_role, external_id)
     return sage_maker_client.deploy(
         image_name=image_name,

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -182,7 +182,7 @@ def deploy(obj, dir, s3_model_location, num_instances, ec2_type, aws_tags, iam_r
     """
     logger.info(ASCII_LOGO)
     logger.info("Started deployment on SageMaker ...\n")
-    
+
     try:
         endpoint_name = api_cloud.deploy(
             dir=dir,

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -163,14 +163,26 @@ def train(
     help='Tags for labeling a training job of the form "tag1=value1;tag2=value2". For more, see '
          'https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.'
 )
+@click.option(
+    u"-r",
+    u"--iam-role-arn",
+    required=False,
+    help="The AWS role to use for the push command"
+)
+@click.option(
+    u"-x",
+    u"--external-id",
+    required=False,
+    help="Optional external id used when using an IAM role"
+)
 @click.pass_obj
-def deploy(obj, dir, s3_model_location, num_instances, ec2_type, aws_tags):
+def deploy(obj, dir, s3_model_location, num_instances, ec2_type, aws_tags, iam_role_arn, external_id):
     """
     Command to deploy ML model(s) on SageMaker
     """
     logger.info(ASCII_LOGO)
     logger.info("Started deployment on SageMaker ...\n")
-
+    
     try:
         endpoint_name = api_cloud.deploy(
             dir=dir,
@@ -178,6 +190,8 @@ def deploy(obj, dir, s3_model_location, num_instances, ec2_type, aws_tags):
             num_instances=num_instances,
             ec2_type=ec2_type,
             docker_tag=obj['docker_tag'],
+            aws_role=iam_role_arn,
+            external_id=external_id,
             tags=aws_tags
         )
 

--- a/tests/commands/test_cloud.py
+++ b/tests/commands/test_cloud.py
@@ -443,6 +443,49 @@ class TestDeploy(object):
 
         assert result.exit_code == 0
 
+    def test_deploy_with_role_and_external_id_happy_case(self):
+        runner = CliRunner()
+
+        with patch(
+                'sagify.commands.initialize._get_local_aws_profiles',
+                return_value=['default', 'sagify']
+        ):
+            with patch.object(
+                    sagify.config.config.ConfigManager,
+                    'get_config',
+                    lambda _: Config(
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1'
+                    )
+            ):
+                with patch(
+                        'sagify.sagemaker.sagemaker.SageMakerClient'
+                ) as mocked_sage_maker_client:
+                    instance = mocked_sage_maker_client.return_value
+                    with runner.isolated_filesystem():
+                        runner.invoke(cli=cli, args=['init'], input='my_app\n1\n2\nus-east-1\n')
+                        result = runner.invoke(
+                            cli=cli,
+                            args=[
+                                'cloud', 'deploy',
+                                '-m', 's3://bucket/model/location/model.tar.gz',
+                                '-n', '2',
+                                '-e', 'ml.c4.2xlarge',
+                                '-r', 'some iam role',
+                                '-x', 'some external id'
+                            ]
+                        )
+
+                        assert instance.deploy.call_count == 1
+                        instance.deploy.assert_called_with(
+                            image_name='sagemaker-img:latest',
+                            s3_model_location='s3://bucket/model/location/model.tar.gz',
+                            train_instance_count=2,
+                            train_instance_type='ml.c4.2xlarge',
+                            tags=None
+                        )
+
+        assert result.exit_code == 0
+
     def test_deploy_with_dir_arg_happy_case(self):
         runner = CliRunner()
 


### PR DESCRIPTION
**What**

Users can now pass two new arguments to `sagify cloud deploy`: *iam-role-arn* and *external-id*.

These are useful when working in cross-account scenarios and third parties.

**Usage**

`sagify cloud deploy -m model-s3-location -n number_of_instances --iam-role-arn role-arn --external-id ext-id`

If a role and external id are passed, we attempt to assume that role instead of using the local profile hardcoded via `init`.

**Tests**
Added test covering the new case.