### PR TITLE
Feature: Job name

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Executes a Docker image in train mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID] [--base-job-name BASE_JOB_NAME]
+    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID] [--base-job-name BASE_JOB_NAME] [--job-name JOB_NAME]
 
 #### Description
 
@@ -394,6 +394,8 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 `--external-id EXTERNAL_ID` or `-x EXTERNAL_ID`: Optional external id used when using an IAM role
 
 `--base-job-name BASE_JOB_NAME` or `-n BASE_JOB_NAME`: Optional prefix for the SageMaker training job
+
+`--job-name JOB_NAME`: Optional name for the SageMaker training job. NOTE: if a `--base-job-name` is passed along with this option, it will be ignored. 
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--base-job-name BASE_JOB_NAME` or `-n BASE_JOB_NAME`: Optional prefix for the SageMaker training job
 
-`--job-name JOB_NAME`: Optional name for the SageMaker training job. NOTE: if a `--base-job-name` is passed along with this option, it will be ignored. 
+`--job-name JOB_NAME`: Optional name for the SageMaker training job
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -501,7 +501,7 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 
 `--base-job-name BASE_JOB_NAME` or `-n BASE_JOB_NAME`: Optional prefix for the SageMaker training job
 
-`--job-name JOB_NAME`: Optional name for the SageMaker training job. NOTE: if a `--base-job-name` is passed along with this option, it will be ignored.
+`--job-name JOB_NAME`: Optional name for the SageMaker training job
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -469,7 +469,7 @@ Executes a Docker image in train mode on AWS SageMaker
 
 #### Synopsis
 
-    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID] [--base-job-name BASE_JOB_NAME]
+    sagify cloud train --input-s3-dir INPUT_DATA_S3_LOCATION --output-s3-dir S3_LOCATION_TO_SAVE_OUTPUT --ec2-type EC2_TYPE [--dir SRC_DIR] [--hyperparams-file HYPERPARAMS_JSON_FILE] [--volume-size EBS_SIZE_IN_GB] [--time-out TIME_OUT_IN_SECS] [--aws-tags TAGS] [--iam-role-arn IAM_ROLE] [--external-id EXTERNAL_ID] [--base-job-name BASE_JOB_NAME] [--job-name JOB_NAME]
 
 #### Description
 
@@ -500,6 +500,8 @@ This command retrieves a Docker image from AWS Elastic Container Service and exe
 `--external-id EXTERNAL_ID` or `-x EXTERNAL_ID`: Optional external id used when using an IAM role
 
 `--base-job-name BASE_JOB_NAME` or `-n BASE_JOB_NAME`: Optional prefix for the SageMaker training job
+
+`--job-name JOB_NAME`: Optional name for the SageMaker training job. NOTE: if a `--base-job-name` is passed along with this option, it will be ignored.
 
 #### Example
 

--- a/sagify/api/cloud.py
+++ b/sagify/api/cloud.py
@@ -54,6 +54,7 @@ def train(
         aws_role,
         external_id,
         base_job_name,
+        job_name,
         tags=None
 ):
     """
@@ -71,6 +72,7 @@ def train(
     :param aws_role: [str], the AWS role assumed by SageMaker while training
     :param external_id: [str], Optional external id used when using an IAM role
     :param base_job_name: [str], Optional prefix for the SageMaker training job
+    :param job_name: [str], Optional name for the SageMaker training job. Overrides `base_job_name`
     :param tags: [optional[list[dict]], default: None], List of tags for labeling a training
         job. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html. Example:
 
@@ -103,6 +105,7 @@ def train(
         output_path=output_s3_dir,
         hyperparameters=hyperparams_dict,
         base_job_name=base_job_name,
+        job_name=job_name,
         tags=tags
     )
 

--- a/sagify/commands/cloud.py
+++ b/sagify/commands/cloud.py
@@ -110,6 +110,12 @@ def upload_data(dir, input_dir, s3_dir):
     help="Optional prefix for the SageMaker training job."
     "If not specified, the estimator generates a default job name, based on the training image name and current timestamp."
 )
+@click.option(
+    u"--job-name",
+    required=False,
+    help="Optional name for the SageMaker training job."
+    "NOTE: if a `--base-job-name` is passed along with this option, it will be ignored."
+)
 @click.pass_obj
 def train(
         obj,
@@ -123,7 +129,8 @@ def train(
         aws_tags,
         iam_role_arn,
         external_id,
-        base_job_name
+        base_job_name,
+        job_name
 ):
     """
     Command to train ML model(s) on SageMaker
@@ -144,7 +151,8 @@ def train(
             tags=aws_tags,
             aws_role=iam_role_arn,
             external_id=external_id,
-            base_job_name=base_job_name
+            base_job_name=base_job_name,
+            job_name=job_name
         )
 
         logger.info("Training on SageMaker succeeded")

--- a/sagify/sagemaker/sagemaker.py
+++ b/sagify/sagemaker/sagemaker.py
@@ -61,6 +61,7 @@ class SageMakerClient(object):
             output_path,
             hyperparameters,
             base_job_name,
+            job_name,
             tags=None
     ):
         """
@@ -75,7 +76,8 @@ class SageMakerClient(object):
         result (model artifacts and output files)
         :param hyperparameters: [dict], Dictionary containing the hyperparameters to initialize
         this estimator with
-        :param base_job_name: [str], Optional prefix for the SageMaker training job.
+        :param base_job_name: [str], Optional prefix for the SageMaker training job
+        :param job_name: [str], Optional name for the SageMaker training job. Overrides `base_job_name`
         :param tags: [optional[list[dict]], default: None], List of tags for labeling a training
         job. For more, see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html. Example:
 
@@ -111,7 +113,7 @@ class SageMakerClient(object):
         if tags:
             estimator.tags = tags
 
-        estimator.fit(input_s3_data_location)
+        estimator.fit(input_s3_data_location, job_name=job_name)
 
         return estimator.model_data
 

--- a/tests/sagemaker/test_sagemaker.py
+++ b/tests/sagemaker/test_sagemaker.py
@@ -108,6 +108,7 @@ def test_train_happy_case():
                         assert sagemaker_estimator_instance.fit.call_count == 1
                         sagemaker_estimator_instance.fit.assert_called_with('s3://bucket/input', job_name='some job name')
 
+
 def test_deploy_happy_case():
     with patch(
             'boto3.Session'

--- a/tests/sagemaker/test_sagemaker.py
+++ b/tests/sagemaker/test_sagemaker.py
@@ -89,6 +89,7 @@ def test_train_happy_case():
                             output_path='s3://bucket/output',
                             hyperparameters={'n_estimator': 3},
                             base_job_name="Some-job-name-prefix",
+                            job_name="some job name"
                         )
                         mocked_sagemaker_estimator.assert_called_with(
                             image_name='image-full-name',
@@ -105,8 +106,7 @@ def test_train_happy_case():
                         )
                         sagemaker_estimator_instance = mocked_sagemaker_estimator.return_value
                         assert sagemaker_estimator_instance.fit.call_count == 1
-                        sagemaker_estimator_instance.fit.assert_called_with('s3://bucket/input')
-
+                        sagemaker_estimator_instance.fit.assert_called_with('s3://bucket/input', job_name='some job name')
 
 def test_deploy_happy_case():
     with patch(


### PR DESCRIPTION
**What**

Users can now pass a new arguments to `sagify cloud train`: _job-name_.

Useful when the name of the jobs is used elsewhere (e.g. CI, analytics). 

**Usage**

`sagify cloud train -i input-data-s3-location -o output-data-s3-location -e ec2-type --job-name MyJobName`

**Tests**
Added test covering the new case and amended existing ones to reflect the addition.