### PR TITLE
Use EC2 instance metadata if no default profile is provided

### DIFF
--- a/sagify/template/{{ cookiecutter.module_slug }}/push.sh
+++ b/sagify/template/{{ cookiecutter.module_slug }}/push.sh
@@ -12,7 +12,12 @@ if [[ ! -z "$role" ]]; then
     if [[ ! -z "$external_id" ]]; then 
         aws configure set profile.${role}.external_id ${external_id}
     fi
-    aws configure set profile.${role}.source_profile default
+    
+    if [[ -z "$profile" ]]; then
+        aws configure set profile.${role}.credential_source Ec2InstanceMetadata
+    else
+        aws configure set profile.${role}.source_profile default
+    fi
     profile=${role}
 elif [ -z "$profile" ]; then 
     profile={{ cookiecutter.aws_profile }}


### PR DESCRIPTION
When using an AWS role, fallback to using an instance's EC2 metadata from the instance profile if no profile is explicitly passed to the command.