### PR TITLE
Feature: Requirements as config

### DIFF
--- a/sagify/api/initialize.py
+++ b/sagify/api/initialize.py
@@ -13,7 +13,7 @@ from distutils.dir_util import copy_tree
 _FILE_DIR_PATH = os.path.dirname(os.path.realpath(__file__))
 
 
-def _template_creation(app_name, aws_profile, aws_region, python_version, output_dir):
+def _template_creation(app_name, aws_profile, aws_region, python_version, output_dir, requirements_dir):
     sagify_module_name = 'sagify'
 
     sagify_exists = os.path.exists(os.path.join(output_dir, sagify_module_name))
@@ -38,10 +38,11 @@ def _template_creation(app_name, aws_profile, aws_region, python_version, output
     config.aws_profile = aws_profile
     config.sagify_module_dir = output_dir
     config.python_version = python_version
+    config.requirements_dir = requirements_dir
     config_manager.set_config(config)
 
 
-def init(sagify_app_name, aws_profile, aws_region, python_version, root_dir):
+def init(sagify_app_name, aws_profile, aws_region, python_version, root_dir, requirements_dir):
     """
     Initializes a SageMaker template
 
@@ -51,6 +52,7 @@ def init(sagify_app_name, aws_profile, aws_region, python_version, root_dir):
     :param aws_region: [str], preferred aws region. Example: 'us-east-1'
     :param python_version: [str], preferred Python version. Options: 3.6 or 2.7.
     :param root_dir: [str], root source directory.
+    :param root_dir: [str], Path to requirements.txt.
     """
     if python_version not in {'2.7', '3.6'}:
         raise ValueError("Invalid Python version. Valid options: 2.7 or 3.6")
@@ -60,5 +62,6 @@ def init(sagify_app_name, aws_profile, aws_region, python_version, root_dir):
         aws_profile=aws_profile,
         aws_region=aws_region,
         python_version=python_version,
-        output_dir=root_dir
+        output_dir=root_dir,
+        requirements_dir=requirements_dir
     )

--- a/sagify/commands/build.py
+++ b/sagify/commands/build.py
@@ -16,9 +16,8 @@ click.disable_unicode_literals_warning = True
 
 
 @click.command()
-@click.option(u"-r", u"--requirements-dir", required=True, help="Path to requirements.txt file")
 @click.pass_obj
-def build(obj, requirements_dir):
+def build(obj):
     """
     Command to build SageMaker app
     """
@@ -33,7 +32,7 @@ def build(obj, requirements_dir):
         config = ConfigManager(config_file_path).get_config()
         api_build.build(
             dir=config.sagify_module_dir,
-            requirements_dir=requirements_dir,
+            requirements_dir=config.requirements_dir,
             docker_tag=obj['docker_tag'],
             image_name=config.image_name,
             python_version=config.python_version)

--- a/sagify/commands/configure.py
+++ b/sagify/commands/configure.py
@@ -25,7 +25,7 @@ def configure(image_name, aws_region, aws_profile, python_version):
     _configure('.', image_name, aws_region, aws_profile, python_version)
 
 
-def _configure(config_dir, image_name, aws_region, aws_profile, python_version):
+def _configure(config_dir, image_name, aws_region, aws_profile, python_version, requirements_dir):
     try:
         config_manager = ConfigManager(os.path.join(config_dir, '.sagify.json'))
         config = config_manager.get_config()
@@ -41,6 +41,9 @@ def _configure(config_dir, image_name, aws_region, aws_profile, python_version):
 
         if python_version is not None:
             config.python_version = python_version
+
+        if requirements_dir is not None:
+            config.requirements_dir = requirements_dir
 
         config_manager.set_config(config)
 

--- a/sagify/commands/configure.py
+++ b/sagify/commands/configure.py
@@ -17,12 +17,13 @@ click.disable_unicode_literals_warning = True
 @click.option(u"--aws-region", required=False, help="AWS Region to use in operations")
 @click.option(u"--aws-profile", required=False, help="AWS Profile to use in operations")
 @click.option(u"--python-version", required=False, help="Python version used when building")
-def configure(image_name, aws_region, aws_profile, python_version):
+@click.option(u"--requirements-dir", required=False, help="Path to requirements.txt")
+def configure(image_name, aws_region, aws_profile, python_version, requirements_dir):
     """
     Command to configure SageMaker template
     """
     logger.info(ASCII_LOGO)
-    _configure('.', image_name, aws_region, aws_profile, python_version)
+    _configure('.', image_name, aws_region, aws_profile, python_version, requirements_dir)
 
 
 def _configure(config_dir, image_name, aws_region, aws_profile, python_version, requirements_dir):

--- a/sagify/commands/initialize.py
+++ b/sagify/commands/initialize.py
@@ -101,6 +101,10 @@ def ask_for_aws_details():
     return chosen_profile, chosen_region
 
 
+def ask_for_requirements_dir():
+    return click.prompt(text="Type in the path to requirements.txt. Example: requirements.txt", type=str).strip('/')
+
+
 @click.command()
 def init():
     """
@@ -120,13 +124,16 @@ def init():
 
     aws_profile, aws_region = ask_for_aws_details()
 
+    requirements_dir = ask_for_requirements_dir()
+
     try:
         api_initialize.init(
             sagify_app_name=sagify_app_name,
             aws_profile=aws_profile,
             aws_region=aws_region,
             python_version=python_version,
-            root_dir=root_dir if root_dir else 'src'
+            root_dir=root_dir if root_dir else 'src',
+            requirements_dir=requirements_dir
         )
 
         logger.info("\nsagify module is created! ヽ(´▽`)/")

--- a/sagify/config/config.py
+++ b/sagify/config/config.py
@@ -4,11 +4,12 @@ from collections import OrderedDict
 
 
 class Config(object):
-    def __init__(self, image_name, aws_profile, aws_region, python_version, sagify_module_dir):
+    def __init__(self, image_name, aws_profile, aws_region, python_version, sagify_module_dir, requirements_dir):
         self.image_name = image_name
         self.aws_profile = aws_profile
         self.aws_region = aws_region
         self.python_version = python_version
+        self.requirements_dir = requirements_dir
         self.sagify_module_dir = sagify_module_dir
 
     def to_dict(self):
@@ -21,7 +22,8 @@ class Config(object):
             aws_profile=input_dict['aws_profile'],
             aws_region=input_dict['aws_region'],
             python_version=input_dict['python_version'],
-            sagify_module_dir=input_dict['sagify_module_dir']
+            sagify_module_dir=input_dict['sagify_module_dir'],
+            requirements_dir=input_dict['requirements_dir']
         )
 
 
@@ -35,7 +37,8 @@ class ConfigManager(object):
                 aws_profile='',
                 aws_region='',
                 python_version='',
-                sagify_module_dir=''
+                sagify_module_dir='',
+                requirements_dir=''
             ))
 
     def get_config(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
-author = Pavlos Mitsoulis Ntompos
-author-email = pavlos@kenza.ai
+author = Pavlos Mitsoulis Ntompos, Ioakeim (Joakim) Lazakis
+author-email = pavlos@kenza.ai, joakim@kenza.ai
 summary = Continuous Machine Learning Training and Deployment on AWS SageMaker
 classifier =
     Development Status :: 5 - Production/Stable

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -20,7 +20,7 @@ def test_build_happy_case():
                 return_value=None
         ):
             with runner.isolated_filesystem():
-                runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
-                result = runner.invoke(cli=cli, args=['build', '-r', 'requirements.txt'])
+                runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
+                result = runner.invoke(cli=cli, args=['build'])
 
     assert result.exit_code == 0

--- a/tests/commands/test_cloud.py
+++ b/tests/commands/test_cloud.py
@@ -33,7 +33,7 @@ class TestUploadData(object):
                     instance = mocked_sage_maker_client.return_value
                     instance.upload_data.return_value = 's3://path-to-data/data/'
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -68,7 +68,7 @@ class TestTrain(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -117,7 +117,7 @@ class TestTrain(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -169,7 +169,7 @@ class TestTrain(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -222,7 +222,7 @@ class TestTrain(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -281,7 +281,7 @@ class TestTrain(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -333,7 +333,7 @@ class TestDeploy(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -375,7 +375,7 @@ class TestDeploy(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -419,7 +419,7 @@ class TestDeploy(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -471,7 +471,7 @@ class TestDeploy(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -516,7 +516,7 @@ class TestBatchTransform(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -562,7 +562,7 @@ class TestBatchTransform(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -610,7 +610,7 @@ class TestBatchTransform(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -666,7 +666,7 @@ class TestBatchTransform(object):
                 ) as mocked_sage_maker_client:
                     instance = mocked_sage_maker_client.return_value
                     with runner.isolated_filesystem():
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[
@@ -749,7 +749,7 @@ class TestHyperparameterOptimization(object):
                         with open('hyperparams_ranges.json', 'w') as f:
                             f.write(hyperparams_ranges)
 
-                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                        runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                         result = runner.invoke(
                             cli=cli,
                             args=[

--- a/tests/commands/test_cloud.py
+++ b/tests/commands/test_cloud.py
@@ -23,7 +23,8 @@ class TestUploadData(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -58,7 +59,8 @@ class TestTrain(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -106,7 +108,8 @@ class TestTrain(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -157,7 +160,8 @@ class TestTrain(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -209,7 +213,8 @@ class TestTrain(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -267,7 +272,8 @@ class TestTrain(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -318,7 +324,8 @@ class TestDeploy(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -359,7 +366,8 @@ class TestDeploy(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -402,7 +410,8 @@ class TestDeploy(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -453,7 +462,8 @@ class TestDeploy(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -497,7 +507,8 @@ class TestBatchTransform(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -542,7 +553,8 @@ class TestBatchTransform(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -589,7 +601,8 @@ class TestBatchTransform(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -644,7 +657,8 @@ class TestBatchTransform(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(
@@ -723,7 +737,8 @@ class TestHyperparameterOptimization(object):
                     sagify.config.config.ConfigManager,
                     'get_config',
                     lambda _: Config(
-                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage'
+                        image_name='sagemaker-img', aws_profile='sagify', aws_region='us-east-1', python_version='3.6', sagify_module_dir='sage',
+                        requirements_dir='requirements.txt'
                     )
             ):
                 with patch(

--- a/tests/commands/test_configure.py
+++ b/tests/commands/test_configure.py
@@ -7,28 +7,37 @@ from unittest import TestCase
 
 from sagify.commands.configure import _configure
 
-Case = namedtuple('Case', 'description, image_name, aws_region, aws_profile, python_version, sagify_module_dir, expected_config')
+Case = namedtuple('Case', 'description, image_name, aws_region, aws_profile, python_version, sagify_module_dir, requirements_dir, expected_config')
 
-t1 = Case('t1: Configure IMAGE NAME', 'new-image-name', None, None, None, None,
-          Config(image_name='new-image-name', aws_profile='', aws_region='', python_version='', sagify_module_dir=''))
+t1 = Case('t1: Configure IMAGE NAME', 'new-image-name', None, None, None, None, None,
+          Config(image_name='new-image-name', aws_profile='', aws_region='',
+                 python_version='', sagify_module_dir='', requirements_dir=''))
 
-t2 = Case('t2: Configure AWS PROFILE', None, None, 'some-profile', None, None,
-          Config(image_name='new-image-name', aws_profile='some-profile', aws_region='', python_version='', sagify_module_dir=''))
+t2 = Case('t2: Configure AWS PROFILE', None, None, 'some-profile', None, None, None,
+          Config(image_name='new-image-name', aws_profile='some-profile', aws_region='',
+                 python_version='', sagify_module_dir='', requirements_dir=''))
 
-t3 = Case('t3: Configure AWS REGION', None, 'us-east-2', None, None, None,
-          Config(image_name='new-image-name', aws_profile='some-profile', aws_region='us-east-2', python_version='', sagify_module_dir=''))
+t3 = Case('t3: Configure AWS REGION', None, 'us-east-2', None, None, None, None,
+          Config(image_name='new-image-name', aws_profile='some-profile',
+                 aws_region='us-east-2', python_version='', sagify_module_dir='', requirements_dir=''))
 
-t4 = Case('t4: Configure PYTHON VERSION', None, None, None, '3.6', None,
-          Config(image_name='new-image-name', aws_profile='some-profile', aws_region='us-east-2', python_version='3.6', sagify_module_dir=''))
+t4 = Case('t4: Configure PYTHON VERSION', None, None, None, '3.6', None, None,
+          Config(image_name='new-image-name', aws_profile='some-profile', aws_region='us-east-2',
+                 python_version='3.6', sagify_module_dir='', requirements_dir=''))
 
-t5 = Case('t5: Configure NOTHING', None, None, None, None, None,
-          Config(image_name='new-image-name', aws_profile='some-profile', aws_region='us-east-2', python_version='3.6', sagify_module_dir=''))
+t5 = Case('t5: Configure REQUIREMENTS DIR', None, None, None, None, None, 'requirements.txt',
+          Config(image_name='new-image-name', aws_profile='some-profile', aws_region='us-east-2',
+                 python_version='3.6', sagify_module_dir='', requirements_dir='requirements.txt'))
 
-t6 = Case('t6: Configure EVERYTHING', 'some-other-image-name', 'us-east-1', 'some-other-profile', '2.7', None,
-          Config(image_name='some-other-image-name', aws_profile='some-other-profile', aws_region='us-east-1', python_version='2.7',
-                 sagify_module_dir=''))
+t6 = Case('t6: Configure NOTHING', None, None, None, None, None, None,
+          Config(image_name='new-image-name', aws_profile='some-profile', aws_region='us-east-2',
+                 python_version='3.6', sagify_module_dir='', requirements_dir='requirements.txt'))
 
-test_cases = [t1, t2, t3, t4, t5, t6]
+t7 = Case('t7: Configure EVERYTHING', 'some-other-image-name', 'us-east-1', 'some-other-profile', '2.7', None, 'other-requirements.txt',
+          Config(image_name='some-other-image-name', aws_profile='some-other-profile', aws_region='us-east-1',
+                 python_version='2.7', sagify_module_dir='', requirements_dir='other-requirements.txt'))
+
+test_cases = [t1, t2, t3, t4, t5, t6, t7]
 
 
 class ConfigureCommandTests(TestCase):
@@ -37,7 +46,7 @@ class ConfigureCommandTests(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             for case in test_cases:
                 try:
-                    updateConfig(tmpdir, case.image_name, case.aws_region, case.aws_profile, case.python_version)
+                    updateConfig(tmpdir, case.image_name, case.aws_region, case.aws_profile, case.python_version, case.requirements_dir)
                     config = ConfigManager(os.path.join(tmpdir, '.sagify.json')).get_config()
                     assert config.to_dict() == case.expected_config.to_dict()
 
@@ -46,5 +55,5 @@ class ConfigureCommandTests(TestCase):
                     raise
 
 
-def updateConfig(config_dir, image_name, aws_region, aws_profile, python_version):
-    _configure(config_dir, image_name, aws_region, aws_profile, python_version)
+def updateConfig(config_dir, image_name, aws_region, aws_profile, python_version, requirements_dir):
+    _configure(config_dir, image_name, aws_region, aws_profile, python_version, requirements_dir)

--- a/tests/commands/test_initialize.py
+++ b/tests/commands/test_initialize.py
@@ -17,7 +17,7 @@ def test_init_happy_case():
             return_value=['default', 'sagemaker']
     ):
         with runner.isolated_filesystem():
-            result = runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+            result = runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
 
             assert os.path.isfile('src/__init__.py')
             assert os.path.isdir('src/sagify')
@@ -55,7 +55,7 @@ def test_init_when_directory_already_exists():
             result = runner.invoke(
                 cli=cli,
                 args=['init'],
-                input='my_app\nN\nmy_app\n1\n2\nus-east-1\n'
+                input='my_app\nN\nmy_app\n1\n2\nus-east-1\nrequirements.txt\n'
             )
 
     assert result.exit_code == -1
@@ -68,6 +68,6 @@ def test_init_when_aws_cli_is_not_configure_locally():
             return_value=[]
     ):
         with runner.isolated_filesystem():
-            result = runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\n')
+            result = runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nrequirements.txt\n')
 
     assert result.exit_code == -1

--- a/tests/commands/test_local.py
+++ b/tests/commands/test_local.py
@@ -21,7 +21,7 @@ class TestTrain(object):
                     return_value=None
             ):
                 with runner.isolated_filesystem():
-                    runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                    runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                     result = runner.invoke(cli=cli, args=['local', 'train'])
 
         assert result.exit_code == 0
@@ -40,7 +40,7 @@ class TestDeploy(object):
                     return_value=None
             ):
                 with runner.isolated_filesystem():
-                    runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\n')
+                    runner.invoke(cli=cli, args=['init'], input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
                     result = runner.invoke(cli=cli, args=['local', 'deploy'])
 
         assert result.exit_code == 0

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -62,5 +62,5 @@ class PushCommandTests(TestCase):
 def runCommands(init_command, push_command):
     runner = CliRunner()
     with runner.isolated_filesystem():
-        runner.invoke(cli=cli, args=init_command, input='my_app\ny\n1\n2\nus-east-1\n')
+        runner.invoke(cli=cli, args=init_command, input='my_app\ny\n1\n2\nus-east-1\nrequirements.txt\n')
         return runner.invoke(cli=cli, args=push_command)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -9,11 +9,13 @@ def test_config(tmpdir):
         "aws_profile": "sagemaker",
         "aws_region": "us-east-1",
         "python_version": "3.6",
-        "sagify_module_dir": "keras-app-img"
+        "sagify_module_dir": "keras-app-img",
+        "requirements_dir": "requirements.txt"
     }
     """)
     config_manager = ConfigManager(str(config_file))
     actual_config_obj = config_manager.get_config()
     assert actual_config_obj.to_dict() == Config(
-        image_name="keras-app-img", aws_profile="sagemaker", aws_region="us-east-1", python_version="3.6", sagify_module_dir="keras-app-img"
+        image_name="keras-app-img", aws_profile="sagemaker", aws_region="us-east-1", python_version="3.6", sagify_module_dir="keras-app-img",
+        requirements_dir="requirements.txt"
     ).to_dict()


### PR DESCRIPTION
**What**
1. We now ask for the path to `requirements.txt` during `init`.
2. The path to `requirements.txt` is now configurable with the `configure` command

Example:

```sagify configure --requirements-dir src/requirements.txt```