### PR TITLE
Feature/ec2 instance metadata role

### DIFF
--- a/sagify/sagemaker/sagemaker.py
+++ b/sagify/sagemaker/sagemaker.py
@@ -18,7 +18,7 @@ _METRIC_REGEX = "([0-9\\.]+)"
 class SageMakerClient(object):
     def __init__(self, aws_profile, aws_region, aws_role=None, external_id=None):
 
-        if aws_role and external_id:
+        if aws_role:
             logger.info("An IAM role and corresponding external id were provided. Attempting to assume that role...")
 
             sts_client = boto3.client('sts')

--- a/sagify/template/sagify_base/push.sh
+++ b/sagify/template/sagify_base/push.sh
@@ -9,37 +9,56 @@ image=$6
 
 if [[ ! -z "$role" ]]; then 
     aws configure set profile.${role}.role_arn ${role}
-    if [[ ! -z "$external_id" ]]; then 
+    if [[ ! -z "$external_id" ]]; then
         aws configure set profile.${role}.external_id ${external_id}
     fi
-    
+
     if [[ -z "$profile" ]]; then
         aws configure set profile.${role}.credential_source Ec2InstanceMetadata
     else
         aws configure set profile.${role}.source_profile ${profile}
     fi
     profile=${role}
-fi 
+fi
 
 # Get the account number associated with the current IAM credentials
-account=$(aws sts get-caller-identity --profile ${profile} --query Account --output text)
+
+if [[ ! -z "$profile" ]]; then
+    account=$(aws sts get-caller-identity --profile ${profile} --query Account --output text)
+else
+    account=$(aws sts get-caller-identity --query Account --output text)
+fi
+
 if [ $? -ne 0 ]; then
     exit 255
 fi
 
 # If the repository doesn't exist in ECR, create it.
 fullname="${account}.dkr.ecr.${region}.amazonaws.com/${image}:${tag}"
-aws ecr describe-repositories --profile ${profile} --region ${region} --repository-names "${image}" > /dev/null 2>&1
+
+if [[ ! -z "$profile" ]]; then
+    aws ecr describe-repositories --profile ${profile} --region ${region} --repository-names "${image}" > /dev/null 2>&1
+else
+    aws ecr describe-repositories --region ${region} --repository-names "${image}" > /dev/null 2>&1
+fi
 
 if [ $? -ne 0 ]; then
     echo "Creating ECR repository"
-    aws ecr create-repository --profile ${profile} --region ${region} --repository-name "${image}" > /dev/null
-else 
+    if [[ ! -z "$profile" ]]; then
+        aws ecr create-repository --profile ${profile} --region ${region} --repository-name "${image}" > /dev/null
+    else
+        aws ecr create-repository --region ${region} --repository-name "${image}" > /dev/null
+    fi
+else
     echo "ECR repository already exists, will push there."
 fi
 
 # Get the login command from ECR and execute it directly
-$(aws ecr get-login --profile ${profile} --region ${region} --no-include-email)
+if [[ ! -z "$profile" ]]; then
+    $(aws ecr get-login --profile ${profile} --region ${region} --no-include-email)
+else
+    $(aws ecr get-login --region ${region} --no-include-email)
+fi
 
 # Push Docker image to ECR
 docker tag ${image}:${tag} ${fullname}


### PR DESCRIPTION
**What**

1. Do not require an _external ID_ when using an _IAM role_. 
2. Do not require profile during "Docker image push".

**Why**

1. One may be running their training workloads under the same AWS account where the instance that runs Sagify is on. No need to pass an _External ID_ which is typically (exclusively?) used in [cross-account scenarios](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html), most of the time to allow a third party to execute AWS calls under a specific account.

2. Not requiring a profile allows EC2 instances to use whichever _IAM role_ is associated with the instance's _Instance Profile_. If the role attached to the instance already has the necessary access for "sagify push", there's no need to pass a profile. In fact, a profile (that is config/credentials files under the shell user's directory) most likely does not even exist in such scenarios.
