### PR TITLE
Do not use AWS profile option when creating SageMaker session if no profile is provided

### DIFF
--- a/sagify/sagemaker/sagemaker.py
+++ b/sagify/sagemaker/sagemaker.py
@@ -35,9 +35,12 @@ class SageMakerClient(object):
                 aws_session_token=credentials['SessionToken'],
                 region_name=aws_region
             )
-        else:
+        elif aws_profile:
             logger.info("No IAM role provided. Using profile {} instead.".format(aws_profile))
             self.boto_session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
+        else:
+            self.boto_session = boto3.Session(region_name=aws_region)
+
 
         self.sagemaker_client = self.boto_session.client('sagemaker')
         self.sagemaker_session = sage.Session(boto_session=self.boto_session)

--- a/sagify/sagemaker/sagemaker.py
+++ b/sagify/sagemaker/sagemaker.py
@@ -41,7 +41,6 @@ class SageMakerClient(object):
         else:
             self.boto_session = boto3.Session(region_name=aws_region)
 
-
         self.sagemaker_client = self.boto_session.client('sagemaker')
         self.sagemaker_session = sage.Session(boto_session=self.boto_session)
         self.role = sage.get_execution_role(self.sagemaker_session) if aws_role is None else aws_role


### PR DESCRIPTION
Complementary pull request to yesterday's #108 @pm3310 

Commit accidentally missed the boat yesterday.