### PR TITLE
Fix docs that refeer aws ecs instead ecr

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -366,9 +366,9 @@ source_profile = test-sagemaker
 
 - You can change the AWS profile/region in an already initialized sagify module by changing the value of `aws_profile`/`aws_region` in `.sagify.json`.
 
-### Push Docker Image to AWS ECS
+### Push Docker Image to AWS ECR
 
-If you have followed all the steps of *Getting Started*, run `sagify push` to push the Docker image to AWS ECS. This step may take some time depending on your internet connection upload speed.
+If you have followed all the steps of *Getting Started*, run `sagify push` to push the Docker image to AWS ECR. This step may take some time depending on your internet connection upload speed.
 
 ### Create S3 Bucket
 

--- a/sagify/api/push.py
+++ b/sagify/api/push.py
@@ -10,7 +10,7 @@ from sagify.log import logger
 
 def push(dir, docker_tag, aws_region, iam_role_arn, aws_profile, external_id, image_name):
     """
-    Push Docker image to AWS ECS
+    Push Docker image to AWS ECR
 
     :param dir: [str], source root directory
     :param docker_tag: [str], the Docker tag for the image

--- a/sagify/commands/push.py
+++ b/sagify/commands/push.py
@@ -23,7 +23,7 @@ click.disable_unicode_literals_warning = True
 @click.pass_obj
 def push(obj, aws_region, iam_role_arn, aws_profile, external_id):
     """
-    Command to push Docker image to AWS ECS
+    Command to push Docker image to AWS ECR
     """
     logger.info(ASCII_LOGO)
 
@@ -46,7 +46,7 @@ def push(obj, aws_region, iam_role_arn, aws_profile, external_id):
         external_id = "" if external_id is None else external_id
         iam_role_arn = "" if iam_role_arn is None else iam_role_arn
 
-        logger.info("Started pushing Docker image to AWS ECS. It will take some time. Please, be patient...\n")
+        logger.info("Started pushing Docker image to AWS ECR. It will take some time. Please, be patient...\n")
 
         api_push.push(
             dir=config.sagify_module_dir,
@@ -57,7 +57,7 @@ def push(obj, aws_region, iam_role_arn, aws_profile, external_id):
             external_id=external_id,
             image_name=image_name)
 
-        logger.info("Docker image pushed to ECS successfully!")
+        logger.info("Docker image pushed to ECR successfully!")
     except ValueError:
         logger.info("This is not a sagify directory: {}".format(dir))
         sys.exit(-1)


### PR DESCRIPTION
I noticed a little problem in the documentation that referenced the AWS [ECS](https://aws.amazon.com/ecs/) service instead of [ECR](https://aws.amazon.com/ecr/?nc2=type_a).